### PR TITLE
Fix wrong lists on Firefox OS privacy notice docs

### DIFF
--- a/firefox_os_privacy_notice/de.md
+++ b/firefox_os_privacy_notice/de.md
@@ -1,6 +1,6 @@
 # Datenschutzhinweis für Firefox OS
 
-8. Mai 2013
+8\. Mai 2013
 {: datetime="2013-05-08" }
 
 Wir nehmen den Schutz Ihrer Daten sehr ernst. In unserer [Datenschutzerklärung](http://www.mozilla.org/de/privacy/) erläutern wir Ihnen, wie Mozilla (das sind wir) mit Ihren Daten, die wir über den Firefox Marketplace erheben, umgeht.

--- a/firefox_os_privacy_notice/hu.md
+++ b/firefox_os_privacy_notice/hu.md
@@ -1,6 +1,6 @@
 # Firefox OS Adatvédelmi Tájékoztató
 
-2013. május 8.
+2013\. május 8.
 {: datetime="2013-05-08" }
 
 Fontos számunkra az Ön személyes adatainak védelme. Amikor a Firefox OS részünkre, azaz a Mozilla (Mozilla Corporation, 650 Castro Street, Suite 300, Mountain View, CA 94041) részére információkat küld, akkor a [Mozilla Adatvédelmi Szabályzata](http://www.mozilla.org/hu/privacy/) szerint kezeljük az információkat.

--- a/firefox_os_privacy_notice/sr.md
+++ b/firefox_os_privacy_notice/sr.md
@@ -1,6 +1,6 @@
 # Firefox OS правила приватности
 
-8. мај 2013. године
+8\. мај 2013. године
 {: datetime="2013-05-08" }
 
 Brinemo za Vašu privatnosti Kada Firefox OS šalje informacije Mozilla-i (to smo mi), [Mozilla Pravila privatnosti](http://www.mozilla.org/sr/privacy/) opisuju kako postupamo sa tim informacijama.


### PR DESCRIPTION
_In other words, a number-period-space sequence at the beginning of a line. To avoid this, you can backslash-escape the period_ - http://daringfireball.net/projects/markdown/syntax#list
