### PR TITLE
[fix bug 1015660] Firefox Privacy Notice update and fix broken links

### DIFF
--- a/firefox_privacy_notice/en-US.md
+++ b/firefox_privacy_notice/en-US.md
@@ -3,7 +3,7 @@
 April 15, 2014
 {: datetime="2014-04-15" }
 
-We care about your privacy. When Firefox sends information to Mozilla (that's us), our [privacy policy](http://www.mozilla.org/en-US/privacy/) describes how we handle that information.
+We care about your privacy. When Firefox sends information to Mozilla (that's us), our [privacy policy](https://www.mozilla.org/privacy/) describes how we handle that information.
 
 ## Things you should know
 
@@ -13,9 +13,9 @@ Firefox automatically connects to us and our service providers to provide update
 * Browser and add-ons updates
   {: #auto-updates }
 
-	Browser Updates: Once per day, Firefox sends the following info to Mozilla when it checks for browser updates: your Firefox version information, language preference, operating system and version. You can turn off updates by following instructions [here](https://support.mozilla.org/en-US/kb/how-stop-firefox-automatically-making-connections?redirectlocale=en-US&redirectslug=Firefox+makes+unrequested+connections#Auto_update_checking) but it may leave you open to security vulnerabilities.
+	Browser Updates: Once per day, Firefox sends the following info to Mozilla when it checks for browser updates: your Firefox version information, language preference, operating system and version. You can [turn off updates by following these instructions](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking) but it may leave you open to security vulnerabilities.
 
-	Add-ons Blocklist: Firefox contacts Mozilla once per day to check for add-on information to check for malicious add-ons. This includes, for example: browser version, OS and version, locale, total number of requests, time of last request, time of day, IP address, and the list of add-ons you have installed. You can turn off this functionality at any time by following [these instructions](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/), but it may leave you open to security vulnerabilities.
+	Add-ons Blocklist: Firefox contacts Mozilla once per day to check for add-on information to check for malicious add-ons. This includes, for example: browser version, OS and version, locale, total number of requests, time of last request, time of day, IP address, and the list of add-ons you have installed. You can [turn off meta data updates](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/) at any time, but it may leave you open to security vulnerabilities.
 
 * Snippets
   {: #snippets }
@@ -29,16 +29,16 @@ Firefox automatically connects to us and our service providers to provide update
 
 	Firefox Health Report (FHR) is designed to provide you with insights about your browser's stability and performance and with support tips should you experience issues, such as high crash rates or slow startup times. Mozilla collects and aggregates your data with that of other Firefox users and sends it back to your browser so you can see how your Firefox performance changes over time. This data includes, for example: device hardware, operating system, Firefox version, add-ons (count and type), timing of browser events, rendering, session restores, length of session, how old a profile is, count of crashes, and count of pages. FHR does not send Mozilla URLs that you visit.
 
-	We use the data sent through FHR to provide users with FHR's functionality, such as helping you analyze and address performance issues with your browser. We also use what we learn from the FHR data in the aggregate to make Firefox better. You can choose to [turn data sharing off](https://support.mozilla.org/en-US/firefox-health-report-understand-your-browser-perf#w_how-to-turn-data-sharing-on-or-off).
+	We use the data sent through FHR to provide users with FHR's functionality, such as helping you analyze and address performance issues with your browser. We also use what we learn from the FHR data in the aggregate to make Firefox better. You can choose to [turn data sharing off](https://support.mozilla.org/kb/firefox-health-report-understand-your-browser-perf#w_how-to-turn-data-sharing-on-or-off).
 
 * Security
   {: #security }
 
 	Firefox automatically checks for malicious or forged web pages, broken add-ons, and third-party issued SSL certificates.
 
-	Secure Website Certificates: When you visit a secure website (i.e. "https"), Firefox will validate the website's certificate. This may involve communicating with a third-party status provider specified by the certificate. Firefox sends to this third-party information identifying the site's [certificate](https://support.mozilla.org/en-US/secure-website-certificate). You can [change your preferences](https://support.mozilla.org/en-US/advanced-settings-browsing-network-updates-encryption#w_certificates-tab), but if you disable the online verification feature, Firefox cannot confirm the identity of the website you are visiting. Turning off this feature may increase the risk of your private information being intercepted. If you encounter an [untrusted connection](https://support.mozilla.org/en-US/kb/connection-untrusted-error-message), you can also choose to send Mozilla the associated certificates.
+	Secure Website Certificates: When you visit a secure website (i.e. "https"), Firefox will validate the website's certificate. This may involve communicating with a third-party status provider specified by the certificate. Firefox sends to this third-party information identifying the site's [certificate](https://support.mozilla.org/kb/secure-website-certificate). You can [change your preferences](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab), but if you disable the online verification feature, Firefox cannot confirm the identity of the website you are visiting. Turning off this feature may increase the risk of your private information being intercepted. If you encounter an [untrusted connection](https://support.mozilla.org/kb/connection-untrusted-error-message), you can also choose to send Mozilla the associated certificates.
 
-	Firefox Forgery and Attack Protection: About twice per hour, Firefox downloads Google's SafeBrowsing lists to help block access to sites and downloads that are malicious or forged (Google's privacy policy is at [https://www.google.com/policies/privacy/](https://www.google.com/policies/privacy/)). For downloaded executables that do not appear in these lists, Firefox may send metadata to the SafeBrowsing service to determine if the download is malicious. Visit [https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work](https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work) to learn more about or disable Safe Browsing. If you disable these features, Firefox cannot warn you of a potentially illegitimate or malicious websites or downloaded files.
+	Firefox Forgery and Attack Protection: About twice per hour, Firefox downloads Google's SafeBrowsing lists to help block access to sites and downloads that are malicious or forged (Google's privacy policy is at [https://www.google.com/policies/privacy/](https://www.google.com/policies/privacy/)). For downloaded executables that do not appear in these lists, Firefox may send metadata to the SafeBrowsing service to determine if the download is malicious. Visit [https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) to learn more about or disable Safe Browsing. If you disable these features, Firefox cannot warn you of a potentially illegitimate or malicious websites or downloaded files.
 
 * Usage statistics (also called "Telemetry" in non-release builds)
   {: #telemetry .inproduct-link}
@@ -47,20 +47,20 @@ Firefox automatically connects to us and our service providers to provide update
 
 	This feature is turned on by default in Nightly, Aurora and Beta builds of Firefox to help those users provide feedback to Mozilla. In the general release version of Firefox, this feature is turned off by default.
 
-	See [here](https://support.mozilla.org/en-US/kb/send-performance-data-improve-firefox) to learn more about the feature and how to enable or disable it. 
+	You can [learn more about Telemetry here](https://support.mozilla.org/kb/send-performance-data-improve-firefox) and how to enable or disable it. 
 
 ---------------------------------------
 
 When you ask it to, Firefox also connects to Mozilla to provide you with features such as Sync, location services, crash reporting, and add-ons.
 {: #optional-features }
 
-* **Sync**: [Firefox Sync](http://www.mozilla.org/en-US/mobile/sync/) is a service that allows you to sync your Firefox bookmarks, browsing history, passwords, and settings across all of your devices. If you use the Sync service, you can read the Firefox Sync privacy notice [here](https://services.mozilla.com/privacy-policy/).
+* **Sync**: [Firefox Sync](https://www.mozilla.org/firefox/sync/) is a service that allows you to sync your Firefox bookmarks, browsing history, passwords, and settings across all of your devices. If you use the Sync service, you can read the [Firefox Sync privacy notice](https://services.mozilla.com/privacy-policy/).
 {: #sync }
 
-* **Location services**: Firefox has a feature that allows sites to request your location (e.g., to allow those sites to show your location on a map). If a site requests your location, Firefox seeks your permission before determining and sharing your location. In order to determine your location, Firefox may use several pieces of data to determine your location, including your operating systems geolocation features, WiFi networks, cell phone towers or IP address. Estimating your location involves sending some of this information to Google's geolocation service, which has it's own [privacy policy](https://www.google.com/privacy/lsf.html).
+* **Location services**: Firefox has a feature that allows sites to request your location (e.g., to allow those sites to show your location on a map). If a site requests your location, Firefox seeks your permission before determining and sharing your location. In order to determine your location, Firefox may use several pieces of data to determine your location, including your operating systems geolocation features, WiFi networks, cell phone towers or IP address. Estimating your location involves sending some of this information to Google's geolocation service, which has its own [privacy policy](https://www.google.com/privacy/lsf.html).
 {: #location-services }
 
-* **Crash reporting**: You have the option to send Mozilla a crash report after Firefox crashes. This report contains technical information for us to improve Firefox including why Firefox crashed, the active URL at time of crash, and the state of computer memory during the crash. The crash report we receive may include personal information. We make portions of crash reports available publicly at [http://crash-stats.mozilla.com/](http://crash-stats.mozilla.com/.). Before publicly posting crash reports, we take steps to automatically redact personal information. We do not redact anything you may write in the comments box.
+* **Crash reporting**: You have the option to send Mozilla a crash report after Firefox crashes. This report contains technical information for us to improve Firefox including why Firefox crashed, the active URL at time of crash, and the state of computer memory during the crash. The crash report we receive may include personal information. We make portions of crash reports available publicly at [http://crash-stats.mozilla.com/](http://crash-stats.mozilla.com/). Before publicly posting crash reports, we take steps to automatically redact personal information. We do not redact anything you may write in the comments box.
 {: #crash-reporter .inproduct-link }
 
 * **Add-ons**: Firefox offers a Get Add-ons page of the Add-ons Manager that features popular add-ons and displays personalized recommendations based on the add-ons you already have installed. To display the personalized recommendations, Firefox sends information to Mozilla, including the list of add-ons you have installed, Firefox version information, and your IP address. This communication only happens when the Get Add-ons area is open and can be turned off by following [these instructions](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/).The add-ons manager in Firefox has a search field where you can enter key words to perform searches and Mozilla collects these key word searches, as well as your Firefox version information, locale, and OS to show you recommendations.


### PR DESCRIPTION
- Fixed broken links and typo in [bug 1015660](https://bugzilla.mozilla.org/show_bug.cgi?id=1015660).
- Improved link text so things make better sense out of context for screen reader users.
- Also removed the hard-coded `en-US` links for mozilla.org and SUMO, as many of these pages are available in multiple languages (those sites will detect the user language and serve the best one automatically).
