### PR TITLE
Bug 1120848 - [Legal][it] QA on legal docs (Jan 2015)

### DIFF
--- a/WebRTC_PrivacyNotice/it.md
+++ b/WebRTC_PrivacyNotice/it.md
@@ -3,30 +3,30 @@
 25 novembre 2014
 {: datetime="2014-11-25" }
 
-Per Mozilla la privacy degli utenti è importante. L'Informativa sulla privacy descrive il modo in cui Mozilla utilizza le informazioni che le vengono inviate da Hello.
+Per Mozilla la privacy degli utenti è importante. L’Informativa sulla privacy descrive il modo in cui Mozilla utilizza le informazioni che le vengono inviate da Hello.
 
 ## Cose da sapere
 
 Quando si effettuano telefonate, alcune informazioni vengono inviate a Mozilla per connettere la chiamata. Una volta connessa la chiamata, le comunicazioni vengono criptate.
 
-* **Account Firefox**: L’utilizzo degli account è facoltativo con Firefox Hello.  Se si effettua l’accesso con un account Firefox, il browser Firefox invierà a Mozilla il nome dell’account dell’utente in modo da indirizzare le chiamate all’utente stesso. Per ulteriori informazioni sul modo in cui i dati sono utilizzati dagli account Firefox, fare clic [qui](https://www.mozilla.org/en-US/privacy/firefox-cloud/).
+* **Account Firefox**: L’utilizzo degli account è facoltativo con Firefox Hello. Se si effettua l’accesso con un account Firefox, il browser Firefox invierà a Mozilla il nome dell’account dell’utente in modo da indirizzare le chiamate all’utente stesso. Per ulteriori informazioni sul modo in cui i dati sono utilizzati dagli account Firefox, fare clic [qui](https://www.mozilla.org/privacy/firefox-cloud/).
 
-* **Contatti**: È possibile importare o aggiungere nuovi contatti per creare una rubrica con indirizzi email, foto del profilo e nomi di persone da chiamare.  Tali informazioni vengono memorizzate localmente sul dispositivo dell’utente.
+* **Contatti**: È possibile importare o aggiungere nuovi contatti per creare una rubrica con indirizzi email, foto del profilo e nomi di persone da chiamare. Tali informazioni vengono memorizzate localmente sul dispositivo dell’utente.
 
-* **Conversazioni**: Per indirizzare le chiamate, il browser Firefox cifra e invia informazioni associate al contatto che si sta cercando di raggiungere, oltre all’URL della conversazione. Tali informazioni verranno eliminati al termine della chiamata.
+* **Conversazioni**: Per indirizzare le chiamate, il browser Firefox cifra e invia informazioni associate al contatto che si sta cercando di raggiungere, oltre all’URL della conversazione. Tali informazioni verranno eliminate al termine della chiamata.
 
-* **Commenti e supporto**: L’invio di commenti a Mozilla è facoltativo.  L’utente potrà fornire utili informazioni a Mozilla inviando segnalazioni di arresto anomalo o errori al forum dell’assistenza.
+* **Commenti e supporto**: L’invio di commenti a Mozilla è facoltativo. L’utente potrà fornire informazioni utili a Mozilla inviando segnalazioni di arresto anomalo o errori al forum dell’assistenza.
 
 ---------------------------------------
 
 Mozilla riceve automaticamente una serie di metriche derivanti dall’utilizzo del servizio.
 
-* **Metriche sulle prestazioni**: Mozilla riceve automaticamente dati sulle prestazioni e sulla reattività relativi alle chiamate e ai tentativi di chiamata, in modo da rilevare problemi, diagnosticarli e migliorare Firefox Hello.  Ad esempio, i dati che riceviamo includono informazioni su qualità dei flussi audio e video, chiamate non riuscite o interrotte, durata delle chiamate, indirizzi IP offuscati, dati hardware e di rete offuscati (ad esempio, nel caso si stia utilizzando una rete Wi-Fi o cellulare) e orari di trasmissione.
+* **Metriche sulle prestazioni**: Mozilla riceve automaticamente dati sulle prestazioni e sulla reattività delle chiamate e dei tentativi di chiamata, in modo da rilevare problemi, diagnosticarli e migliorare Firefox Hello. Ad esempio, i dati che riceviamo includono informazioni su qualità dei flussi audio e video, chiamate non riuscite o interrotte, durata delle chiamate, indirizzi IP offuscati, dati hardware e di rete offuscati (ad esempio, nel caso si stia utilizzando una rete Wi-Fi o cellulare) e orari di trasmissione.
 
-* **Metriche di utilizzo**: Mozilla riceve informazioni aggregate sul numero di persone che utilizzano il Servizio, sui tipi di sistemi operativi e browser impiegati e sui paesi in cui viene utilizzato il Servizio.
+* **Metriche di utilizzo**: Mozilla riceve informazioni aggregate sul numero di persone che utilizzano il Servizio, sui tipi di sistemi operativi e browser utilizzati e sui paesi in cui viene utilizzato il Servizio.
 
 * **Rapporti**: Mozilla riceve informazioni aggregate sul numero di persone che utilizzano il Servizio, sui tipi di sistemi operativi e browser impiegati e sui paesi in cui viene utilizzato il Servizio.
 
 ---------------------------------------
 
-Firefox Hello viene offerto agli utenti in collaborazione con TokBox, Inc. (“TokBox”) e invia dati a TokBox nell’ambito della funzionalità del servizio.  Questo avviso descrive esclusivamente come Mozilla gestisce le informazioni che riceve dagli utenti. Per ulteriori informazioni sulla gestione dati da parte di TokBox, leggere la relativa [Informativa sulla privacy]( https://tokbox.com/support/privacy-policy)
+Firefox Hello viene offerto agli utenti in collaborazione con TokBox, Inc. (“TokBox”) e invia dati a TokBox nell’ambito della funzionalità del servizio. Questo avviso descrive esclusivamente in che modo Mozilla gestisce le informazioni che riceve dagli utenti. Per ulteriori informazioni sulla gestione dati da parte di TokBox, consultare la relativa [Informativa sulla privacy]( https://tokbox.com/support/privacy-policy)

--- a/WebRTC_ToS/it.md
+++ b/WebRTC_ToS/it.md
@@ -3,31 +3,31 @@
 25 novembre 2014
 {: datetime="2014-11-25" }
 
-### 1. Introduzione 
+### 1. Introduzione
 
-Firefox Hello è un servizio di comunicazioni voce e video end-to-end e in tempo reale (“Servizio”) offerto da Mozilla.  Leggere attentamente e per intero il presente documento (“Termini”), poiché illustra i diritti e le responsabilità dell’utente relativamente all’utilizzo di Firefox Hello per inviare o ricevere comunicazioni.
+Firefox Hello è un servizio di comunicazioni voce e video end-to-end e in tempo reale (“Servizio”) offerto da Mozilla. Leggere attentamente e per intero il presente documento (“Termini”), poiché illustra i diritti e le responsabilità dell’utente relativamente all’utilizzo di Firefox Hello per inviare o ricevere comunicazioni.
 
 ### 2. Registrazione account
 
-Potrebbe essere necessario creare un account Firefox per utilizzare determinate funzioni del Servizio, come l’importazione dei contatti da un altro servizio o la creazione di nuovi contatti.  Quando si registra un account Firefox, è necessario accettare i relativi [Termini di servizio](https://www.mozilla.org/en-US/about/legal/terms/services) e l’[Informativa sulla privacy](https://www.mozilla.org/en-US/privacy/firefox-cloud).
+Potrebbe essere necessario creare un account Firefox per utilizzare determinate funzioni del Servizio, come l’importazione dei contatti da un altro servizio o la creazione di nuovi contatti. Quando si registra un account Firefox, è necessario accettare i relativi [Termini di servizio](https://www.mozilla.org/about/legal/terms/services) e l’[Informativa sulla privacy](https://www.mozilla.org/privacy/firefox-cloud).
 
 ### 3. Funzioni
 
-Il Servizio viene offerto all’utente in collaborazione con TokBox, Inc. (Nel documento si fa riferimento a ToxBox anche come licenziatario.)  Il Servizio è integrato in Firefox, per consentire di effettuare facilmente chiamate vocali e video tra Firefox e utenti di qualsiasi browser o dispositivo abilitato per WebRTC.  Il Servizio è soggetto a modifiche.  Consultare il [sito dell'assistenza](https://support.mozilla.org/products/firefox) di Mozilla per domande sulle funzioni. 
+Il Servizio viene offerto all’utente in collaborazione con TokBox, Inc. (Nel documento si fa riferimento a ToxBox anche come licenziatario.) Il Servizio è integrato in Firefox, per consentire di effettuare facilmente chiamate vocali e video tra Firefox e utenti di qualsiasi browser o dispositivo compatibile con WebRTC. Il Servizio è soggetto a modifiche. Consultare il [sito dell’assistenza](https://support.mozilla.org/products/firefox) di Mozilla per domande sulle funzioni.
 
 ### 4. Informativa sulla privacy
 
 L’[Informativa sulla privacy di Firefox Hello](https://www.mozilla.org/privacy/) spiega quali informazioni vengono inviate quando si utilizza il Servizio e in che modo vengono gestite queste informazioni.
 
-### 5. Contenuti e utilizzo 
+### 5. Contenuti e utilizzo
 
-L’utente è a conoscenza che il Servizio consente di trasmettere determinate informazioni (come video o immagini) (“Contenuti”).  Con il presente atto, l’utente concede a Mozilla e ai suoi licenziatari tutti i diritti necessari per offrire il Servizio e accetta di utilizzare il Servizio in conformità alle [Condizioni d’uso](https://www.mozilla.org/about/legal/acceptable-use) di Mozilla. L’utente è l’unico responsabile dei Contenuti trasmessi e delle relative conseguenze. 
+L’utente è a conoscenza che il Servizio consente di trasmettere determinate informazioni (come video o immagini) (“Contenuti”). Con il presente atto, l’utente concede a Mozilla e ai suoi licenziatari tutti i diritti necessari per offrire il Servizio e accetta di utilizzare il Servizio in conformità alle [Condizioni d’uso](https://www.mozilla.org/about/legal/acceptable-use) di Mozilla. L’utente è l’unico responsabile dei Contenuti trasmessi e delle relative conseguenze.
 
-Per ulteriori informazioni su come segnalare una violazione di copyright o del marchio commerciale, fare clic [qui](https://www.mozilla.org/about/legal/report-abuse/).
+Per ulteriori informazioni su come segnalare una violazione di copyright o di marchi commerciali, utilizzare [questa pagina](https://www.mozilla.org/about/legal/report-abuse/).
 
 ### 6. Diritti di proprietà di Mozilla e TokBox
 
-Né Mozilla né i suoi licenziatari concedono all’utente alcun diritto di proprietà intellettuale sul Servizio non specificamente indicato nei presenti Termini.  Ad esempio, i presenti Termini non concedono il diritto di utilizzare copyright, nomi commerciali, marchi commerciali, marchi di servizio, loghi, nomi di domini o altre caratteristiche distintive del brand Mozilla o dei suoi licenziatari.  
+Né Mozilla né i suoi licenziatari concedono all’utente alcun diritto di proprietà intellettuale sul Servizio non specificamente indicato nei presenti Termini. Ad esempio, i presenti Termini non concedono il diritto di utilizzare copyright, nomi commerciali, marchi commerciali, marchi di servizio, loghi, nomi di domini o altre caratteristiche distintive del brand Mozilla o dei suoi licenziatari.
 
 Il software Mozilla viene distribuito in base alla versione corrente della Mozilla Public License, o di altre licenze similmente permissive.
 
@@ -37,7 +37,7 @@ Di tanto in tanto, potrebbe essere necessario eseguire interventi di manutenzion
 
 I presenti Termini sono applicabili all’utilizzo del Servizio da parte dell’utente e continueranno a essere applicabili fino a quando l’utente non cesserà detto utilizzo oppure in seguito a notifica da parte di Mozilla o di TokBox. L’utente può scegliere di interrompere il Servizio in qualsiasi momento e per qualsiasi ragione, terminandone l’utilizzo.
 
-Mozilla può sospendere o interrompere l’accesso al Servizio o all’account Firefox dal parte dell’utente in qualsiasi momento e per qualsiasi motivo, incluso, senza limitazioni, nel caso in cui ritenga che: (i) l’utente abbia violato i presenti Termini (ii) l’utente abbia creato un rischio di fatto o abbia esposto Mozilla o TokBox a possibili rischi legali; oppure (iii) la fornitura dei Servizi all’utente non sia più commercialmente giustificabile. Verrò fatto il possibile per inviare una notifica all’utente utilizzando l’indirizzo email associato all’account Firefox, oppure al suo successivo tentativo di accesso al Servizio.
+Mozilla può sospendere o interrompere l’accesso al Servizio o all’account Firefox dal parte dell’utente in qualsiasi momento e per qualsiasi motivo, incluso, senza limitazioni, nel caso in cui ritenga che: (i) l’utente abbia violato i presenti Termini (ii) l’utente abbia creato un rischio di fatto o abbia esposto Mozilla o TokBox a possibili rischi legali; oppure (iii) la fornitura dei Servizi all’utente non sia più commercialmente giustificabile. Verrà fatto il possibile per inviare una notifica all’utente utilizzando l’indirizzo email associato all’account Firefox, oppure al suo successivo tentativo di accesso al Servizio.
 
 In tutti questi casi, i presenti Termini saranno considerati conclusi, inclusa, senza limitazioni, la licenza dell’utente per l’utilizzo del Servizio, fatta eccezione per le seguenti sezioni, che continueranno a essere applicabili: Indennizzo, Esclusione di garanzia, Limitazione di responsabilità, Varie ed eventuali.
 
@@ -57,7 +57,7 @@ FATTA ECCEZIONE PER QUANTO PREVISTO DALLA LEGGE, LE PARTI INDENNIZZATE NON SARAN
 
 ### 10. Modifiche ai presenti Termini
 
-I presenti Termini potranno essere aggiornati di volta in volta per integrare una nuova funzione del Servizio o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i blog e i forum. L’utilizzo continuato del Servizio da parte dell’utente dopo la data di entrata in vigore delle modifiche citate costituisce l’accettazione delle stesse. Per una maggiore praticità, la decorrenza della revisione verrà pubblicata in cima a questa pagina.
+I presenti Termini potranno essere aggiornati di volta in volta per integrare una nuova funzione del Servizio o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i blog e i forum. L’utilizzo continuato del Servizio da parte dell’utente dopo la data di entrata in vigore delle modifiche citate costituisce l’accettazione delle stesse. Per una maggiore praticità, la decorrenza della revisione verrà pubblicata all’inizio di questa pagina.
 
 ### 11. Varie ed eventuali
 

--- a/Websites_ToU/it.md
+++ b/Websites_ToU/it.md
@@ -7,7 +7,7 @@
 
 #### 1\. Introduzione
 
-Si consiglia di leggere attentamente e per interno e termini contenuti nel presente documento (“Termini”), poiché illustrano i diritti e le responsabilità dell’utente quando visita uno dei siti web di Mozilla (“Siti web”) o i relativi feed, social media, newsletter e email (insieme ai siti web, collettivamente “Comunicazioni”). Accedendo o registrandosi per ricevere Comunicazioni, l’utente accetta di rispettare i presenti Termini.
+Si consiglia di leggere attentamente e per intero i termini contenuti nel presente documento (“Termini”), poiché illustrano i diritti e le responsabilità dell’utente quando visita uno dei siti web di Mozilla (“Siti web”) o i relativi feed, social media, newsletter e email (insieme ai siti web, collettivamente “Comunicazioni”). Accedendo o registrandosi per ricevere Comunicazioni, l’utente accetta di rispettare i presenti Termini.
 
 I nostri siti web includono domini multipli come mozilla.org, mozillians.org, firefox.com, mozillafestival.org, openstandard.com, openbadges.org e webmaker.org. L’utente potrà riconoscere i nostri siti web da soprannomi come Bugzilla@Mozilla, BMO, MozWiki, MoPad, Webmaker, MozReps, MDN, Marketplace, One and Done, SUMO e AMO.
 Alcuni dei nostri siti web connettono l’utente a link, app o componenti aggiuntivi forniti da terze parti e soggetti a Termini separati.
@@ -17,46 +17,46 @@ Alcuni dei nostri siti web connettono l’utente a link, app o componenti aggiun
 
 Alcuni siti web richiedono la registrazione per ottenere un account, in modo da accedere a ulteriori funzioni di un sito web o di un altro servizio Mozilla. Se applicabili, all’utente saranno presentati termini aggiuntivi. L’utente è responsabile di tutte le attività svolte dal proprio account.
 
-Alcuni siti web consentono di creare un nome utente durante la procedura di registrazione. L’utilizzo del nome utente deve essere conforme alla nostra [Informativa sul corretto utilizzo](https://www.mozilla.org/about/legal/acceptable-use/). 
+Alcuni siti web consentono di creare un nome utente durante la procedura di registrazione. L’utilizzo del nome utente deve essere conforme alla nostra [Informativa sul corretto utilizzo](https://www.mozilla.org/about/legal/acceptable-use/).
 
 
 #### 3\. Licenza per i Contenuti
 
-Le nostre Comunicazioni includono contenuti come articoli, immagini, fotografie, commenti, codice software, clip audio e video e altri materiali (collettivamente, “Contenuti”).  I Contenuti sono creati da Mozilla, dai collaboratori ai progetti Mozilla e da altre fonti. 
+Le nostre Comunicazioni includono contenuti come articoli, immagini, fotografie, commenti, codice software, clip audio e video e altri materiali (collettivamente “Contenuti”). I Contenuti sono creati da Mozilla, dai collaboratori ai progetti Mozilla e da altre fonti.
 
-I Contenuti creati da Mozilla vengono in genere resi disponibili per la condivisione e il riutilizzo pubblici mediante licenze aperte quali Creative Commons (per i materiali espressivi) o la Mozilla Public License (per il codice software).  Nella maggioranza dei casi, chiediamo ai collaboratori di Mozilla di rilasciare i Contenuti con licenze open source. 
+I Contenuti creati da Mozilla vengono in genere resi disponibili per la condivisione e il riutilizzo pubblici mediante licenze aperte quali Creative Commons (per i materiali espressivi) o la Mozilla Public License (per il codice software). Nella maggioranza dei casi, chiediamo ai collaboratori di Mozilla di rilasciare i Contenuti con licenze open source.
 
-Parte dei Contenuti delle nostre Comunicazioni viene acquisito da fonti che proibiscono l’ulteriore utilizzo dei loro Contenuti senza previa autorizzazione.  Ove possibile, all’interno dei Contenuti o nel piè di pagina del sito web apparirà un avviso con la licenza applicabile. L’utente accetta di attenersi a questi avvisi.  Si tengano presenti le seguenti specifiche:
+Parte dei Contenuti delle nostre Comunicazioni viene acquisito da fonti che proibiscono l’ulteriore utilizzo dei loro Contenuti senza previa autorizzazione. Ove possibile, all’interno dei Contenuti o nel piè di pagina del sito web apparirà un avviso con la licenza applicabile. L’utente accetta di attenersi a questi avvisi. Si tengano presenti le seguenti specifiche:
 
-* Alcuni Contenuti indicano espressamente che l’autore non intende rendere applicabile una licenza aperta.  In tal caso, l’utente dovrà contattare l’autore o un suo agente per ottenere l’autorizzazione all’utilizzo di tali Contenuti.  Le domande sui contenuti creati da Mozilla possono essere inviate a: licensing@mozilla.org.
-* Alcuni Contenuti includono marchi commerciali, veste commerciale, loghi e punti di forza dei marchi di Mozilla e di altre parti (“Marchi commerciali”).  A eccezione di qualche limitata circostanza, i Marchi commerciali non possono essere usati senza previa autorizzazione scritta dei titolari.  [Ulteriori informazioni sui marchi commerciali di Mozilla.](https://www.mozilla.org/foundation/trademarks/policy/)
-* Il software utilizzato dai nostri siti web è concesso in licenza in base alla MPL o altre licenze open source analogamente permissive.  Per ulteriori informazioni sulla licenza specifica, consultare l’archivio GitHub applicabile. 
+* Alcuni Contenuti indicano espressamente che l’autore non intende rendere applicabile una licenza aperta. In tal caso, l’utente dovrà contattare l’autore o un suo agente per ottenere l’autorizzazione all’utilizzo di tali Contenuti. Le domande sui contenuti creati da Mozilla possono essere inviate a: licensing@mozilla.org.
+* Alcuni Contenuti includono marchi commerciali, veste grafica aziendale, loghi ed elementi distintivi dei marchi di Mozilla e di altre parti (“Marchi commerciali”). A eccezione di qualche limitata circostanza, i Marchi commerciali non possono essere usati senza previa autorizzazione scritta dei titolari. [Ulteriori informazioni sui marchi commerciali di Mozilla.](https://www.mozilla.org/foundation/trademarks/policy/)
+* Il software utilizzato dai nostri siti web è concesso in licenza in base alla MPL o altre licenze open source analogamente permissive. Per ulteriori informazioni sulla licenza specifica, consultare l’archivio GitHub applicabile.
 
 
 #### 4\. Invii di Contenuti
 
-È possibile contribuire con propri Contenuti quando si interagisce con le nostre Comunicazioni, inviando, ad esempio, commenti su articoli, post su blog, codici, grafici o altro materiale scritto (individualmente, “Invio”).
-   
+È possibile contribuire con propri Contenuti quando si interagisce con le nostre Comunicazioni, inviando, ad esempio, commenti su articoli, post su blog, codice, grafici o altro materiale scritto (individualmente “Invio”).
+
 L’utente accetta i termini elencati di seguito, in relazione a ciascun Invio.
 
-* L’utente dichiara e garantisce che ogni suo Invio sarà conforme ai presenti Termini, alle[Condizioni d’uso](https://www.mozilla.org/about/legal/acceptable-use/) di Mozilla e a eventuali altri termini che possono regolare l’Invio.
+* L’utente dichiara e garantisce che ogni suo Invio sarà conforme ai presenti Termini, alle [Condizioni d’uso](https://www.mozilla.org/about/legal/acceptable-use/) di Mozilla e a eventuali altri termini che possono regolare l’Invio.
 * L’utente concede a Mozilla una licenza non esclusiva, gratuita, globale e trasferibile in sub-licenza (ai collaboratori di Mozilla) per l’utilizzo del proprio Invio in relazione alle Comunicazioni e alla promozione, online e offline, della missione, dei prodotti e dei servizi di Mozilla.
 * L’utente accetta che il proprio Invio sarà accessibile ad altri utenti registrati del servizio applicabile o al pubblico.
-* Se l’Invio dell’utente contiene materiale espressivo o codice software, l’utente accetta di concederlo in licenza compatibilmente alla modalità prevista dal sito web a cui ha indirizzato l’Invio. 
+* Se l’Invio dell’utente contiene materiale espressivo o codice software, l’utente accetta di concederlo in licenza compatibilmente alla modalità prevista dal sito web a cui ha indirizzato l’Invio.
 * L’utente dichiara e garantisce di avere i diritti necessari per concedere, a sua volta, i diritti concessi nel presente atto; inoltre, l’utente dichiara e garantisce che gli utilizzi previsti dai presenti Termini non costituiranno violazione dei diritti di proprietà, o di proprietà intellettuale, di terzi.
 * L’utente comprende e accetta che Mozilla si riservi il diritto, a sua esclusiva discrezione, di rivedere, modificare o rimuovere ogni Invio che riterrà opinabile o in violazione di detti Termini.
 
 
 #### 5\. Informativa sulla privacy e cookie
 
- L’[Informativa sulla privacy dei siti web, comunicazioni e cookie di Mozilla](https://www.mozilla.org/privacy/websites/) descrive come vengono gestite le informazioni che riceviamo dagli utenti in relazione alle nostre Comunicazioni. L’Informativa sulla privacy spiega, ad esempio, che determinati cookie vengono inseriti nei nostri siti web e come disattivarli.
+ L’[Informativa sulla privacy dei siti web, comunicazioni e cookie di Mozilla](https://www.mozilla.org/privacy/websites/) descrive in che modo vengono gestite le informazioni che riceviamo dagli utenti in relazione alle nostre Comunicazioni. L’Informativa sulla privacy spiega, ad esempio, che determinati cookie vengono inseriti nei nostri siti web e come disattivarli.
 
 
 #### 6\. Comunicazioni ed eventi
 
 Se l’utente si abbona alle newsletter o registra un account in relazione a uno dei nostri siti web, potrà ricevere email di natura commerciale da Mozilla in relazione al proprio account (ad esempio, aggiornamenti legali, relativi alla privacy o alla sicurezza).
 
-Alcuni dei nostri siti web dispongono di strumenti online che consentono di inviare email ad altri. Ad esempio, l’utente può invitare i propri contatti ad eventi mediante l’account Webmaker.  L’utente accetta di non utilizzare in modo improprio gli indirizzi email di terzi (ad esempio, inviando spam). 
+Alcuni dei nostri siti web dispongono di strumenti online che consentono di inviare email ad altri. Ad esempio, l’utente può invitare i propri contatti a eventi mediante l’account Webmaker. L’utente accetta di non utilizzare in modo improprio gli indirizzi email di terzi (ad esempio, inviando spam).
 
 Altri siti web, come MozReps e Webmaker, offrono strumenti online che consentono agli utenti di organizzare eventi fisici a cui tutti possono partecipare. Usare cautela e giudizio quando si partecipa agli eventi.
 
@@ -67,9 +67,9 @@ Per ulteriori informazioni su come segnalare una violazione di copyright o march
 
 #### 8\. Fine; Cessazione
 
-I presenti Termini continueranno ad essere applicati fino alla cessazione da parte dell’utente o di Mozilla. L’utente potrà scegliere di interrompere la validità dei termini in qualsiasi momento e per qualsiasi ragione, cessando di utilizzare le nostre Comunicazioni e, se applicabile, eliminando il proprio account.
+I presenti Termini continueranno a essere applicati fino alla cessazione da parte dell’utente o di Mozilla. L’utente potrà scegliere di interrompere la validità dei termini in qualsiasi momento e per qualsiasi ragione, cessando di utilizzare le nostre Comunicazioni e, se applicabile, eliminando il proprio account.
 
-Mozilla può sospendere o interrompere l’accesso dell’utente alle Comunicazioni in qualsiasi momento o per qualsiasi motivo, incluso, senza limitazioni, nel caso in cui ragionevolmente ritenga che: (i) l’utente abbia violato questi Termini, la nostra Informativa sul corretto utilizzo, o un’altra informativa applicabile; (ii) l’utente abbia creato un rischio di fatto o abbia esposto Mozilla a possibili rischi legali; oppure (iii) la fornitura di Comunicazioni all’utente da parte di Mozilla non sia più ritenuta commercialmente giustificabile.
+Mozilla può sospendere o interrompere l’accesso dell’utente alle Comunicazioni in qualsiasi momento o per qualsiasi motivo, incluso, senza limitazioni, nel caso in cui ragionevolmente ritenga che: (i) l’utente abbia violato questi Termini, la nostra Informativa sul corretto utilizzo o un’altra informativa applicabile; (ii) l’utente abbia creato un rischio di fatto o abbia esposto Mozilla a possibili rischi legali; oppure (iii) la fornitura di Comunicazioni all’utente da parte di Mozilla non sia più ritenuta commercialmente giustificabile.
 
 In tutti questi casi, i presenti Termini saranno considerati conclusi, fatta eccezione per le seguenti sezioni, che continueranno a essere applicabili: Indennizzo, Esclusione di garanzia, Limitazione di responsabilità, Varie ed eventuali.
 
@@ -86,22 +86,22 @@ LE COMUNICAZIONI SONO FORNITE "COSÌ COME SONO" CON TUTTI I DIFETTI. NELLA MISUR
 FATTA ECCEZIONE PER QUANTO PREVISTO DALLA LEGGE, MOZILLA E LE PARTI INDENNIZZATE NON SARANNO RESPONSABILI PER NESSUN DANNO INDIRETTO, SPECIALE, INCIDENTALE, CONSEQUENZIALE O ESEMPLARE DERIVANTE O IN QUALSIASI MODO RELATIVO AI PRESENTI TERMINI O ALL’USO O ALL’INCAPACITÀ DI USARE LE COMUNICAZIONI, INCLUSI, SENZA LIMITAZIONI, DANNI DIRETTI E INDIRETTI PER PERDITA DI REPUTAZIONE, INTERRUZIONE DEL LAVORO, PERDITA DI PROFITTI, PERDITA DI DATI E GUASTI O MALFUNZIONAMENTI DEL COMPUTER, ANCHE NEL CASO IN CUI LE PARTI SIANO STATE AVVISATE DELLA POSSIBILITÀ DI TALI DANNI E INDIPENDENTEMENTE DALLA SPIEGAZIONE (CONTRATTO, ILLECITO E ALTRO) SUI CUI SI BASA TALE RIVENDICAZIONE. LA RESPONSABILITÀ COLLETTIVA DI MOZILLA E DELLE PARTI INDENNIZZATE IN BASE A QUESTO CONTRATTO, NON SUPERERÀ L’IMPORTO DI 500$ (CINQUECENTO DOLLARI USA). ALCUNE GIURISDIZIONI NON CONSENTONO L’ESCLUSIONE O LA LIMITAZIONE DEI DANNI INCIDENTALI, CONSEQUENZIALI O SPECIALI, PERTANTO QUESTA ESCLUSIONE E LIMITAZIONE POTREBBE NON ESSERE APPLICABILE ALL’UTENTE.
 
 
-#### 11\. Modifiche ai presenti Termini  
+#### 11\. Modifiche ai presenti Termini
 
-Mozilla potrà aggiornare i presenti Termini di volta in volta per integrare una nuova funzione delle Comunicazioni o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i post sui blog, i banner, le email o i forum. L’utilizzo continuato delle Comunicazioni da parte dell’utente dopo la data di entrata in vigore delle modifiche citate costituisce l’accettazione delle stesse. Per una maggiore praticità, la decorrenza della revisione verrà pubblicata in cima a questa pagina.
+Mozilla potrà aggiornare i presenti Termini di volta in volta per integrare una nuova funzione delle Comunicazioni o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i post sui blog, i banner, le email o i forum. L’utilizzo continuato delle Comunicazioni da parte dell’utente dopo la data di entrata in vigore delle modifiche citate costituisce l’accettazione delle stesse. Per una maggiore praticità, la decorrenza della revisione verrà pubblicata all’inizio di questa pagina.
 
-#### 12\. Varie ed eventuali  
+#### 12\. Varie ed eventuali
 
 I presenti Termini costituiscono l’intero accordo tra Mozilla e l’utente relativamente all’utilizzo delle Comunicazioni e prevarranno su eventuali versioni precedenti degli stessi Termini. Le Comunicazioni e i presenti Termini sono governati dalle leggi dello Stato della California, USA, con esclusione delle disposizioni in materia di conflitto di leggi. Ogni rivendicazione o controversia insorgente dalle Comunicazioni o dai presenti Termini sarà soggetta all’esclusiva giurisdizione dei tribunali della contea di Santa Clara, California; l’utente acconsente alla giurisdizione personale dei tribunali citati. Se una qualsiasi parte dei presenti Termini sarà ritenuta non valida o non applicabile, le parti rimanenti resteranno in vigore a tutti gli effetti. In caso di conflitto tra una versione tradotta dei presenti Termini e la versione in lingua inglese, prevarrà la versione in lingua inglese. In caso di conflitto tra i presenti Termini e ulteriori termini pertinenti, prevarranno questi ultimi.
 
 #### 13\. Contattateci
 
-Mozilla Corporation  
-Att.: Mozilla - Avvisi legali  
-331 E. Evelyn Ave.,  
-Mountain View, CA 94041  
-USA  
-Telefono:  +1 650-903-0800  
-Fax: +1 650-903-0875  
+Mozilla Corporation
+Att.: Mozilla - Avvisi legali
+331 E. Evelyn Ave.,
+Mountain View, CA 94041
+USA
+Telefono: +1 650-903-0800
+Fax: +1 650-903-0875
 Avvisi legali presso mozilla.com
 

--- a/acceptable_use_policy/it.md
+++ b/acceptable_use_policy/it.md
@@ -2,30 +2,24 @@
 
 Si proibisce l’utilizzo di qualsiasi prodotto o servizio di Mozilla per:
 
-* Qualsiasi attività illegale o altrimenti in violazione delle leggi applicabili
-* Minacciare, molestare altre persone o violare il loro diritto alla privacy; 
-inviare comunicazioni non richieste; intercettare, monitorare o modificare comunicazioni non destinate all’utente
-* Violare le linee guida sulla partecipazione alla Comunità di Mozilla (per informazioni, vedere 
-<https://www.mozilla.org/about/governance/policies/participation/>)
-* Danneggiare gli utenti mediante l’utilizzo di virus, spyware o malware, worm, 
-cavalli di troia, bombe a orologeria o altri codici o istruzioni potenzialmente dannosi
-•	Raccogliere informazioni personalmente identificabili, inclusi, senza limitazioni, nomi di account o indirizzi email
-* Impegnarsi in qualsiasi attività che interferisca con i servizi e prodotti di 
-Mozilla o ne interrompa il funzionamento o l’efficacia (o quella dei server e delle reti connesse ai servizi di Mozilla)
-* Riprodurre, duplicare, copiare, vendere, scambiare o rivendere i servizi o i prodotti di 
-Mozilla per qualsiasi scopo
-* Violare il copyright, il marchio commerciale o ledere i diritti di proprietà intellettuale 
-di terze parti
+* Qualsiasi attività illegale o altrimenti in violazione delle leggi applicabili.
+* Minacciare, molestare altre persone o violare il loro diritto alla privacy; inviare comunicazioni non richieste; intercettare, monitorare o modificare comunicazioni non destinate all’utente.
+* Violare le linee guida sulla partecipazione alla Comunità di Mozilla (per ulteriori informazioni consultare <https://www.mozilla.org/about/governance/policies/participation/>)
+* Danneggiare gli utenti mediante l’utilizzo di virus, spyware o malware, worm, cavalli di troia, bombe a orologeria o altro codice potenzialmente dannoso.
+* Raccogliere informazioni d’identificazione personale, inclusi, senza limitazioni, nomi di account o indirizzi email.
+* Impegnarsi in qualsiasi attività che interferisca con i servizi e prodotti di Mozilla o ne interrompa il funzionamento o l’efficacia (o quella dei server e delle reti connesse ai servizi di Mozilla).
+* Riprodurre, duplicare, copiare, vendere, scambiare o rivendere i servizi o i prodotti di Mozilla per qualsiasi scopo.
+* Violare il copyright, il marchio commerciale o ledere i diritti di proprietà intellettuale di terze parti.
 * Caricare, scaricare, trasmettere, visualizzare o concedere l’accesso a contenuti:
-    * Di natura illegale o che promuovano attività illegali
-    * Non appropriati, quali materiali osceni o pornografici, descrizioni esplicite di atti sessuali o violenti, oppure immagini di sfruttamento o violenza su minori
-    * Che ledano i diritti di chiunque, inclusi il diritto di proprietà intellettuale o altri diritti di proprietà, o diritti relativi alla privacy e alla divulgazione
-    * Ingannevoli, fuorvianti, fraudolenti oppure realizzati con finalità di phishing o di altri tipi di violazione dell’identità
-    * Finalizzati a promuovere il gioco d’azzardo
-    * Che pubblicizzino o promuovano prodotti o servizi controllati o illegali
-    * Finalizzati a umiliare, intimidire, incitare violenza o incoraggiare azioni pregiudizievoli contro persone o gruppi sulla base di età, genere, razza, etnia, nazionalità, religione, orientamento sessuale, disabilità, posizione geografica o altra categoria protetta o che costituiscano un incitamento all’odio
-    * Che inducano erroneamente un utente a decidere di acquistare un prodotto
+    * Di natura illegale o che promuovano attività illegali.
+    * Non appropriati, quali materiali osceni o pornografici, descrizioni esplicite di atti sessuali o violenti, oppure immagini di sfruttamento o violenza su minori.
+    * Che ledano i diritti di chiunque, inclusi il diritto di proprietà intellettuale o altri diritti di proprietà, o diritti relativi alla privacy e alla divulgazione.
+    * Ingannevoli, fuorvianti, fraudolenti oppure realizzati con finalità di phishing o di altri tipi di violazione dell’identità.
+    * Finalizzati a promuovere il gioco d’azzardo.
+    * Che pubblicizzino o promuovano prodotti o servizi controllati o illegali.
+    * Finalizzati a umiliare, intimidire, incitare violenza o incoraggiare azioni pregiudizievoli contro persone o gruppi sulla base di età, genere, razza, etnia, nazionalità, religione, orientamento sessuale, disabilità, posizione geografica o altra categoria protetta o che costituiscano un incitamento all’odio.
+    * Che inducano erroneamente un utente a decidere di acquistare un prodotto.
 
 Questo elenco ha fini puramente illustrativi, non è definitivo e può essere aggiornato.
 
-Mozilla si riserva il diritto di rimuovere qualsiasi contenuto o sospendere qualsiasi utente che violi le presenti condizioni o i termini di servizio del prodotto applicabile. 
+Mozilla si riserva il diritto di rimuovere qualsiasi contenuto o sospendere qualsiasi utente che violi le presenti condizioni o i termini di servizio del prodotto applicabile.

--- a/firefox_cloud_services_ToS/it.md
+++ b/firefox_cloud_services_ToS/it.md
@@ -57,7 +57,7 @@ La sezione iniziale riepiloga i termini descritti in seguito. Questo riepilogo v
 
 10. #### Modifiche ai presenti Termini
 
-    Mozilla potrà aggiornare i presenti Termini di volta in volta per integrare una nuova funzione dei Servizi o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i blog e i forum. L’uso continuato dei Servizi da parte dell’utente dopo la data di entrata in vigore di tali modifiche costituisce l’accettazione delle stesse. Per una maggiore praticità, pubblicheremo la decorrenza della revisione in cima a questa pagina.
+    Mozilla potrà aggiornare i presenti Termini di volta in volta per integrare una nuova funzione dei Servizi o per chiarire un provvedimento. I Termini aggiornati saranno pubblicati online. Se le modifiche sono sostanziali, annunceremo la loro pubblicazione mediante i canali solitamente utilizzati da Mozilla per questa funzione, come i blog e i forum. L’uso continuato dei Servizi da parte dell’utente dopo la data di entrata in vigore di tali modifiche costituisce l’accettazione delle stesse. Per una maggiore praticità, pubblicheremo la decorrenza della revisione all’inizio di questa pagina.
 
 11. #### Varie ed eventuali
 


### PR DESCRIPTION
* acceptable_use_policy *
Just syntax cleanup, use period ad the end of a list item (the formal alternative is to use a semi-colon for all items but the last, and start each time with lowercase).

Other pages have en-US hard-coded links, some straight quotes, multiple spaces and typos.