### PR TITLE
Add Thunderbird Privacy Policy, Bug 1133266

### DIFF
--- a/thunderbird_privacy_policy/en-US.md
+++ b/thunderbird_privacy_policy/en-US.md
@@ -1,0 +1,171 @@
+# Mozilla Thunderbird Privacy Policy
+
+October 11, 2011
+{: datetime="2011-10-11" }
+
+This privacy policy explains how Mozilla Corporation (“Mozilla”), a wholly owned subsidiary of the non-profit Mozilla Foundation, collects and uses information about users of the official Mozilla Thunderbird software (“Thunderbird”). It does not apply to other Mozilla products or services, to Mozilla’s websites or browser, or to beta, testing, or experimental versions of Thunderbird.
+
+## Overview
+
+In this privacy policy, we talk about:
+
+* [Definitions of the Types of Information](#types)
+* [Information Collected by Thunderbird](#collected)
+* [Information Thunderbird Sends to Websites, Email Providers, and ISPs](#disclosed)
+* [Tracking and Cookies](#tracking)
+* [Data Practices for Interactive Product Features](#features), including
+  * [Addons](#addons),
+  * [Personas](#personas), and
+  * [Usage Statistics](#telemetry)
+* [What Mozilla Does to Secure Data](#security)
+* [Legal Process and Others Disclosures](#legal)
+  * [What and When We Share with Third Parties](#third-parties)
+  * [Transfer of Data to the U.S.](#stateside)
+  * [Mozilla’s Approach to Data Retention](#retention)
+* [How Mozilla Discloses Changes to this Policy](#changes)
+* [How to Contact Mozilla about this Policy](#contact)
+
+## Types of Information ## {: #types }
+
+"**Personal Information**" is information that you provide to us that personally identifies you, such as your name, phone number, or email address. Except as described below, Mozilla does not collect or require end-users of Thunderbird to provide Personal Information.
+
+"**Non-Personal Information**" is information that cannot be directly associated with a specific person or entity. Non-Personal Information includes but is not limited to your computer’s configuration and the version of Thunderbird you use.
+
+"**Potentially Personal Information**" is information that is Non-Personal Information in and of itself but that could be used in conjunction with other information to personally identify you. For example, Uniform Resource Locators (“URLs”) (the addresses of web pages) or Internet Protocol (“IP”) addresses (the addresses of computers on the Internet), which are Non-Personal Information in and of themselves, could be Personal Information when combined with Internet service provider (“ISP”) records. 
+
+“**Aggregate Data**” is information that is recorded about users and collected into groups so that it no longer reflects or references an individually identifiable user.
+
+## Information Collected by Thunderbird ## {: #collected }
+
+Thunderbird is software, which allows users to integrate and manage their online communications, including email and other types of online messaging. Each Thunderbird user chooses which online accounts he or she wishes to access using Thunderbird.
+
+When you set up Thunderbird to access your email account, you will need to enter information and credentials for that account, such as your name, email address, and password. Thunderbird stores this information on your computer.
+
+In addition to your credentials, Thunderbird needs certain Non-Personal, technical information from your account providers to configure each email account you use. This includes details about which servers to connect to and the protocols and settings that they use. To simplify the set-up process, Thunderbird tries to locate this information for you. During this setup process, Thunderbird may try to contact external DNS servers, standard autoconfiguration URIs, and Mozilla's configuration database to try and work the settings needed for your account. This may involve sending part or all of your email address, but never involves sending your password. When Thunderbird does this, the parties contacted may retain logs of those requests.
+
+Thunderbird stores other information on your computer, including information you enter in your Thunderbird address book and copies of your email messages. Thunderbird stores this information locally on your computer and does not transmit it to Mozilla.
+
+## Information Thunderbird Sends to Websites, Email Providers, and ISPs ## {: #disclosed }
+
+Thunderbird includes web-browser-like features, such as the ability to subscribe to and view RSS feeds and web pages. When you use these web-based functions, Thunderbird automatically sends Non-Personal and Potentially Personal Information along with your request. This may include, for example, the type of browser you are using, your language preference, the referring site, and your IP address. Whenever you send or receive email, Thunderbird attaches similar information in the communication to your email provider and to email recipient(s).
+
+Like other messaging products, any information sent by Thunderbird may be logged by the websites you access, your email provider and recipients, the internet service provider you are using, or any intermediary network between you and them. What information is logged and how that information is used depends on the policies of each of these different parties, and is outside Mozilla's control. Each website and service provider determines its own privacy practices for the distribution and use of this Non-Personal Information and Potentially Personal Information. If you are concerned about how a website or service provider will use this information, check out its privacy policy. To find out more about how Mozilla uses this information on its own websites and services, see the Mozilla Privacy Policy.
+
+Whenever you send or receive email, that message is transmitted over the Internet through a connection that is unencrypted, an unscrupulous intermediary may be able to read or modify your messages. You can gain some additional measure of protection by only communicating with your email provider using an encrypted protocol, but this is not a complete protection.
+
+## Tracking and Cookies ## {: #tracking }
+
+When you use Thunderbird’s web-browser features to access a website, the website may place cookies on your computer. A cookie is information stored on your computer by a website you visit. Cookies often store your settings for a website, such as your preferred language or location, or a unique identifier. When you return to the site, Thunderbird sends back the cookies that belong to the site. This allows the site to present you with information customized to fit your needs. Cookies can store a wide range of information, including personally identifiable information (such as your name, home address, e-mail address, or telephone number). Because of their ability to store Personal Information, or references to such information, cookies can allow websites to track the online movements of particular individuals. 
+
+Thunderbird itself does not set any cookies on behalf of Mozilla. However, Mozilla may sometimes set cookies in accordance with the Mozilla Privacy Policy, e.g., for the [Blocklist](#blocklist) (see below) or for other website visits.
+
+By default, the activities of storing and sending cookies are invisible to you. However, you can change your Thunderbird settings to allow you to approve or deny cookie storage requests, delete stored cookies automatically when you close Thunderbird, and more.
+
+## Data Practices for Interactive Product Features ## {: #features }
+
+### Add-ons ### {: #addons }
+
+One thing that makes Thunderbird so flexible is the ability for you to add various add-ons, extensions, and themes to Thunderbird, thereby creating a custom messaging system that fits your needs. The following features show how Thunderbird provides the ability both to obtain additional add-ons easily and to protect against potentially harmful add-ons.
+
+#### Get Add-ons Page
+
+Thunderbird offers a Get Add-ons page of the Add-ons Manager that features popular add-ons and displays personalized recommendations based on the add-ons you already have installed. This page can be accessed by clicking on the “Get Add-ons” tab of the Thunderbird Add-ons Manager. To display the personalized recommendations, Thunderbird sends certain information to Mozilla, including the list of add-ons you have installed, Thunderbird version information, and your IP address. This communication only happens when the Get Add-ons area is open and can be turned off at any time by opting out of Automatic Updates from the Add-ons Manager.
+
+#### Add-on Information and Searches
+
+To keep the information displayed to you about your installed add-ons up to date, Thunderbird communicates with Mozilla once a day to update add-on descriptions, home pages, download counts, screenshots, and ratings. This communication includes the list of add-ons you have installed, Thunderbird version information, how long it took Thunderbird to start up, and your IP address. You can turn off this functionality at any time by [opting out](https://support.mozilla.org/en-US/kb/thunderbird-makes-unrequested-connections#w_extension-blocklist-updating) of Automatic Updates from the Add-ons Manager.
+
+If you enter keywords into the search field for the Add-ons Manager, those keywords will be sent to Mozilla to perform the search, along with Potentially Personal Information (such as IP address) normally transferred to perform such functionality.
+
+### Automated Update Service ### {: #updateservice }
+
+Thunderbird’s automatic update feature periodically checks to see if an updated version of Thunderbird and installed add-ons are available from Mozilla.
+
+This feature sends Non-Personal Information to Mozilla, including the version of Thunderbird you are using, build ID and target, update channel, your language preference, and your operating system. This feature also sends Potentially Personal Information to Mozilla in the form of your IP address and a cookie that contains a unique numeric value to distinguish individual Thunderbird installs. Mozilla uses this information to provide you with updated versions of Thunderbird and to understand the usage patterns of Thunderbird users. We use this information to improve our products and services and to support decision-making regarding feature and capacity planning.
+
+Mozilla does not collect or track any Personal Information or any information about the emails you send/receive or the websites you visit, and Mozilla does not release the raw information we obtain from this Thunderbird feature to the public. We may release reports containing Aggregate Data so that our global community can make better product and design decisions. To prevent Mozilla from obtaining this information, you can turn this feature off in Thunderbird’s preferences.
+
+### Blocklist Feature ### {: #blocklist }
+
+Thunderbird also offers a Blocklist feature. With this feature, once a day Thunderbird does a regularly scheduled, automatic check to see if you have any harmful add-ons or plug-ins installed. If so, this feature disables add-ons or plug-ins that Mozilla has determined contain known vulnerabilities or major user-facing issues or fatal bugs (e.g., Thunderbird crashes on startup or something causes an endless loop). You may view the current list of Blocklisted items. This feature sends Non-Personal Information to Mozilla, including the version of Thunderbird you are using, operating system version, build ID and target, update channel, and your language preference. This feature also sends Potentially Personal Information to Mozilla in the form of your IP address and a cookie. In addition, Mozilla also uses this feature to analyze Thunderbird usage patterns so we may improve our products and services, including planning features and capacity. Currently there is no basic user interface to disable the Blocklist feature.
+
+This feature can be disabled by following the instructions in [this article](https://support.mozilla.org/en-US/kb/thunderbird-makes-unrequested-connections#w_extension-blocklist-updating). Disabling the Blocklist feature is not recommended as it may result in using extensions known to be untrustworthy.
+
+### Crash-Reporting Feature ### {: #crash-reporter }
+
+Thunderbird has a crash-reporting feature that sends a report to Mozilla when Thunderbird crashes. Mozilla uses the information in the crash reports to diagnose and correct the problems in Thunderbird that caused the crash. Though this feature starts automatically after Thunderbird crashes, it does not send information to Mozilla until you explicitly authorize it to do so.
+
+By default, this feature sends a variety of Non-Personal Information to Mozilla, including the stack trace (a detailed description of which parts of the Thunderbird code were active at the time of the crash) and the type of computer you are using. It also gives you have the option to include Personal Information (including your email address), Potentially Personal Information (including your IP address and the URL of the site you were visiting when Thunderbird crashed), and a comment. Thunderbird Crash Reporter also sends a list of all add-ons that you were using at the time of the crash, and the time since: the start-up of the program, the last crash, and the last install.
+
+Mozilla only makes Non-Personal Information (i.e., generic information about your computer, the stack trace, and any comment given by the user) available in the public reports available online at [http://crash-stats.mozilla.com/](http://crash-stats.mozilla.com/). We recommend you not include any personal information in comments in crash reporter.
+
+### Personas ### {: #personas }
+
+Thunderbird’s Personas feature allows you to use a theme to personalize the look of Thunderbird.
+
+#### Applying Personas
+
+When you apply a Persona to Thunderbird, Mozilla collects your IP address, the date and time you applied the Persona to Thunderbird, and the URL you used to make the application as well as the URL you were visiting immediately before that (known as the “referrer” URL).
+
+#### Creating a Custom Persona
+
+If you are creating a Custom Persona for your own use, Mozilla does not collect any Personal Information.
+
+#### Contributing a Design to the Personas Gallery
+
+The Personas gallery is where you can browse all the available designs. If you contribute a design or image (each a “Persona”) to the Personas gallery, Mozilla collects the following Personal Information: (1) your username and (2) your email address. Your username will be used to attribute your Persona to you and will be publicly available on the Personas gallery. You do not have to provide your real name; you can use a nickname or avatar. Mozilla will not make your email address publicly available without your consent or share it with any third parties other than Mozilla’s service providers. Mozilla will use your email address only to contact you regarding your design or to provide any additional information that you elect or opt in to receive.
+
+#### Personas’ Interactive Product Features
+
+After you have selected your Persona, it is stored on your computer. Once per day the Personas service checks to see if your selected Persona has been updated. This feature sends the same information that web browsers typically transfer with any HTTP requests including user agent and your IP address.
+
+We use this information to improve our products and services and to support decision-making regarding feature and capacity planning. Mozilla is an open organization that believes in sharing as much information as possible about its products, its operations, and its associations. Accordingly, we may release public reports containing Aggregate Data so that our global community and Personas partners may make better product and design decisions. For example, we think it is good for users of Personas to know which are the most popular Personas and Personas designers to know how many times their Persona was downloaded.
+
+### Usage Statistics ### {: #telemetry }
+
+Beginning with version 7, Thunderbird includes functionality that is turned off by default to send to Mozilla non-personal usage, performance, and responsiveness statistics about user interface features, memory, and hardware configuration. The only Potentially Personal Information sent to Mozilla when this functionality has been enabled is IP addresses. Usage statistics are transmitted using SSL (a method of protecting data in transit) and help us improve future versions of Thunderbird. Once sent to Mozilla, usage statistics are stored in an aggregate form and made available to a broad range of developers, including both Mozilla employees and public contributors. Once this functionality is enabled, users can disable it in Thunderbird’s Options/Preferences. Simply deselect the "Submit performance data" item.
+
+## What Mozilla Does to Secure Data ## {: #security }
+
+Mozilla is committed to protecting your Personal Information from unauthorized access, alteration, disclosure, or destruction. We undertake a range of security measures including physical access restraints, technical security monitoring, and internal security reviews of the environment. We also have policies in place to prohibit employees from viewing Personal Information without business justification. Additionally, it is our policy to ensure that Mozilla employees and contractors are bound by confidentiality obligations. Although we make good faith efforts to maintain the security of such Personal Information, we cannot guarantee that it will remain free from unauthorized access, use, disclosure, or alteration. Further, while we work hard to ensure the integrity and security of our network and systems, we cannot guarantee that our security measures will prevent unauthorized persons from illegally accessing or obtaining this information.
+
+### Secure Website Certificate Verification ### {: #site-verification }
+
+When you visit a secure website or access secure remote content via emails, Thunderbird may check the identity of that secure remote service using any status provider mentioned in the certificate provided by that service. Thunderbird sends only the certificate identification to the certificate provider, not the exact URL you are visiting. Sending these verification requests to third parties is sometimes important to ensure your connection to a site is secure; to help maintain your security, Thunderbird may deny access to the site if it can't verify your connection using the third party. If the certificate is no longer valid, you will receive an error page that states why the certificate is not valid and you will not be able to access that website. The technical name for this process is OCSP or On-line Certificate Status Protocol. You may [disable](https://support.mozilla.org/en-US/kb/configuring-certificates) online certificate verification in Thunderbird's preferences (Mac) / options (PC) under the encryption tab. If you do this, none of the information discussed here will be sent to any third party certificate provider. However, if you choose to disable the online verification feature, Thunderbird will not be able to confirm the identity of the website you are visiting, which may put you at greater risk of having your private information intercepted. In this case, Thunderbird will also not show the identity of the website in the URL bar.
+
+## Legal Process and Other Disclosures ## {: #legal }
+
+Consistent with our privacy commitments, we will scrutinize third party requests for information about you for compliance with the law, including those coming from governmental agencies or civil litigants. We may access, use, preserve or disclose information about you only when we have a good faith belief that it is reasonably necessary to do so to satisfy the applicable law, regulation, legal process or lawful governmental request of any country, or to protect the rights, property or safety of Mozilla, its users or the public. We will provide notice of legal process or governmental requests unless prohibited to do so by law or the circumstances warrant otherwise.
+
+### What and When We Share with Third Parties ### {: #third-parties }
+
+Mozilla’s policy is to make Personal Information, such as your name and email address, and Potentially Personal Information, such as the URL of the site you last visited, only available to its employees, contractors, and selected contributors who signed confidentiality agreements that prohibit them from using or disclosing such information other than for approved Mozilla purposes.
+
+We also work with third parties who provide infrastructure or back-end services (like content delivery networks, bandwidth providers, and services of an administrative nature). We may share Personal Information about you with such third parties for the purpose of enabling these third parties to provide such services. Additionally, Mozilla may need to transfer Personal Information to an affiliate or successor in the event of a change of our corporate structure or status, such as in the event of a restructuring, sale, or bankruptcy.
+
+### Transfer of Data to the U.S. ### {: #stateside }
+
+Mozilla is a global organization and operates in different countries. Privacy laws and common practices vary from country to country. Some countries may provide for less legal protection of your personal data; others may provide more legal protection. By using Thunderbird, you consent to the transfer of the information collected, as outlined by this Policy, to Mozilla or its third party service providers in the United States, the Netherlands, and other places where our distributed, third party content delivery network exists (which is in several countries around the world), which countries may provide a lesser level of data protection than in your country of residence.
+
+### Mozilla’s Approach to Data Retention ### {: #retention }
+
+We will retain any information collected for the period necessary to fulfill the purposes outlined in this Policy unless a longer retention period is required by law and/or regulations.
+
+## How Mozilla Discloses Changes to this Policy ## {: #changes }
+
+Mozilla may change the Thunderbird Privacy Policy from time to time. Any and all changes will be reflected on this page. Substantive changes may also be announced through the standard mechanisms by which Mozilla communicates with its users and community, such as Mozilla's "announce" mailing list and newsgroup. It is your responsibility to ensure that you understand the terms of this Privacy Policy. You should periodically check this page for any changes to the current policy. If we make an update to this Privacy Policy that is materially less restrictive in our use or disclosure of Personal Information that we collected prior to the update, we will provide you with prior notice of the pending update and seek your consent by posting notice on our website or by contacting you using the email address that you may provide to us (if any).
+
+## How to Contact Mozilla about this Policy ## {: #contact }
+
+You may request access, correction, or deletion of Personal Information or Potentially Personal Information, as permitted by law. We will seek to comply with such requests, provided that we have sufficient information to identify the Personal Information or Potentially Personal Information related to you.
+
+Any such requests or other questions or concerns regarding this Policy and Mozilla's data protection practices should be addressed to:
+
+Mozilla Corporation<br>
+Attn: Legal Notices - Privacy<br>
+331 E. Evelyn Ave.<br>
+Mountain View, CA 94041
+
+Phone: +1-650-903-0800
+
+E-mail: privacy@mozilla.com


### PR DESCRIPTION
This is currently at https://www.mozilla.org/en-US/thunderbird/legal/privacy/

* Updated support article links to use `support.mozilla.org` instead of `support.mozillamessaging.com`
* No other content changes