### PR TITLE
Use non-breaking spaces in Mozilla Privacy Policy for French

### DIFF
--- a/mozilla_privacy_policy/fr.md
+++ b/mozilla_privacy_policy/fr.md
@@ -2,28 +2,28 @@
 
 Votre confidentialité constitue un facteur important dont Mozilla (nous) se soucie dans le développement de ses produits et services. Nous nous engageons à être transparent et ouvert et nous voulons que vous sachiez comment nous recevons vos informations et ce que nous en faisons une fois qu’elles sont en notre possession.
 
-## Qu’entendons-nous par « informations personnelles » ?
+## Qu’entendons-nous par « informations personnelles » ?
 
-Pour nous, les « informations personnelles » désignent toutes les informations qui vous identifient, par exemple, votre nom ou adresse électronique.
+Pour nous, les « informations personnelles » désignent toutes les informations qui vous identifient, par exemple, votre nom ou adresse électronique.
 
-Toute information en dehors de ce cadre constitue une « information non-personnelle ».
+Toute information en dehors de ce cadre constitue une « information non-personnelle ».
 
 Si nous stockons vos informations personnelles avec des informations non-personnelles, nous considérerons l’ensemble comme des informations personnelles. Si nous éliminons toutes les informations personnelles d’un ensemble de données, les informations restantes seront non-personnelles.
 
-## Comment avons-nous connaissance d’informations à votre sujet ?
+## Comment avons-nous connaissance d’informations à votre sujet ?
 
-Nous prenons connaissance d’informations vous concernant dans les situations suivantes :
+Nous prenons connaissance d’informations vous concernant dans les situations suivantes :
 
-* lorsque vous nous les donnez directement (vous choisissez de nous envoyer des rapports de « plantage » de Firefox, par exemple) ;
-* lorsque nous les collectons directement par nos produits et services (lors d’une vérification de mise à jour de votre version de Firefox, par exemple) ;
-* lorsque quelqu’un d’autre nous donne des informations sur votre compte (par ex., Thunderbird opère avec votre fournisseur de messagerie pour configurer votre compte) ; ou
+* lorsque vous nous les donnez directement (vous choisissez de nous envoyer des rapports de « plantage » de Firefox, par exemple) ;
+* lorsque nous les collectons directement par nos produits et services (lors d’une vérification de mise à jour de votre version de Firefox, par exemple) ;
+* lorsque quelqu’un d’autre nous donne des informations sur votre compte (par ex., Thunderbird opère avec votre fournisseur de messagerie pour configurer votre compte) ; ou
 * lorsque nous essayons d’en savoir plus en fonction des informations que vous nous avez données (par ex., lorsque nous utilisons votre adresse IP pour personnaliser la langue de certains de vos services).
 
-## Que faisons-nous avec vos informations une fois obtenues ?
+## Que faisons-nous avec vos informations une fois obtenues ?
 
 Lorsque vous nous donnez des informations personnelles, nous les utilisons conformément aux autorisations que vous nous avez fournies. De manière générale, nous utilisons vos informations pour nous permettre de vous offrir de nouveaux produits et services et/ou d’améliorer les existants.
 
-## Dans quels cas partageons-nous vos informations avec d’autres ?
+## Dans quels cas partageons-nous vos informations avec d’autres ?
 
 * Lorsque vous nous avez autorisé à le faire.
 * Pour le traitement ou la fourniture des produits et services, mais uniquement si les entités qui reçoivent vos informations sont obligées contractuellement d’utiliser les procédures de gestion des données approuvées par Mozilla.
@@ -32,18 +32,18 @@ Lorsque vous nous donnez des informations personnelles, nous les utilisons confo
 * Lorsque nous jugeons qu’il est nécessaire d’éviter tout préjudice à votre personne ou à un tiers. Nous ne partagerons vos informations de cette manière que si nous estimons de bonne foi qu’il est raisonnablement nécessaire de protéger vos droits, votre propriété ou votre sécurité ou ceux d’autres utilisateurs, de Mozilla ou du public.
 * Si notre structure organisationnelle ou notre statut change (si nous sommes soumis à une restructuration, acquisition ou faisons faillite), nous pourrions passer vos informations à un successeur ou affilié.
 
-## Comment conservons-nous et protégeons-nous vos informations personnelles ?
+## Comment conservons-nous et protégeons-nous vos informations personnelles ?
 
 Nous nous engageons à protéger vos informations personnelles une fois que nous les avons obtenues. Nous mettons en place des mesures de sécurité physiques, commerciales et techniques. Malgré nos efforts, si nous avons connaissance d’une effraction dans notre sécurité, nous vous avertirons pour que vous puissiez adopter des mesures de protection adéquates.
 
 Aussi, nous ne souhaitons pas conserver vos informations personnelles si nous n’en avons plus besoin. Par conséquent nous ne les garderons que le temps nécessaire pour réaliser les actions pour lesquelles nous les avons collectées. Lorsque nous n’en avons plus besoin, nous les détruisons sauf si la loi exige que nous les conservions plus longtemps.
 
-## Que souhaitons-nous que vous sachiez encore ?
+## Que souhaitons-nous que vous sachiez encore ?
 
-Nous sommes une organisation mondiale et nos ordinateurs se trouvent dans des emplacements divers dans le monde entier. Nous faisons aussi appel à des fournisseurs de services dont les ordinateurs peuvent également se trouver dans divers pays. Ceci signifie que vos informations peuvent « atterrir » sur l’un des ordinateurs situés dans un autre pays, et ce pays peut avoir des réglementations différentes des nôtres en matière de protection des données. En nous communiquant vos informations, vous nous autorisez à effectuer ce transfert d’informations. Quel que soit le pays où se trouvent vos informations, nous respectons le droit applicable ainsi que les engagements que nous avons pris dans cette politique de confidentialité.
+Nous sommes une organisation mondiale et nos ordinateurs se trouvent dans des emplacements divers dans le monde entier. Nous faisons aussi appel à des fournisseurs de services dont les ordinateurs peuvent également se trouver dans divers pays. Ceci signifie que vos informations peuvent « atterrir » sur l’un des ordinateurs situés dans un autre pays, et ce pays peut avoir des réglementations différentes des nôtres en matière de protection des données. En nous communiquant vos informations, vous nous autorisez à effectuer ce transfert d’informations. Quel que soit le pays où se trouvent vos informations, nous respectons le droit applicable ainsi que les engagements que nous avons pris dans cette politique de confidentialité.
 
 Si vous avez moins de 13 ans, nous ne voulons pas vos informations personnelles et vous ne devez pas nous les communiquer. Si vous êtes parent d’un enfant de moins de 13 ans et pensez qu’il nous a communiqué ses informations personnelles, veuillez [nous contacter](https://www.mozilla.org/privacy/policies/firefox-os/) pour éliminer ces informations.
 
-## Que se passe-t-il si nous modifions cette politique ?
+## Que se passe-t-il si nous modifions cette politique ?
 
-Nous pourrions être amenés à modifier cette politique : dans ce cas, nous vous avertirons.
+Nous pourrions être amenés à modifier cette politique : dans ce cas, nous vous avertirons.


### PR DESCRIPTION
Fixing a bad visual issue at the end of https://www.mozilla.org/fr/privacy/ :

Que se passe-t-il si nous modifions cette politique
 ?