### PR TITLE
Fix markdown indentation for Bug 1192086

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ File a pull request that updates your locale's markdown file to match the `en-US
 Following is a list of directories in this repository and either their URL counterparts on the web or directions to see the document in case it isn't easily linkable.  The URLs below will link to the *English (US)* versions of the document but replacing *en-US* in the URL with an available language code will show alternative languages.
 
 * /firefox_cloud_services_PrivacyNotice
-  * https://www.mozilla.org/en-US/privacy/firefox-cloud/
+    * https://www.mozilla.org/en-US/privacy/firefox-cloud/
 * /firefox_cloud_services_ToS
 * /firefox_os_privacy_notice
-  * https://www.mozilla.org/en-US/privacy/firefox-os/
+    * https://www.mozilla.org/en-US/privacy/firefox-os/
 * /firefox_privacy_notice
-  * https://www.mozilla.org/en-US/privacy/firefox/
+    * https://www.mozilla.org/en-US/privacy/firefox/
 * /marketplace_developer_agreement
-  * https://marketplace.firefox.com/developers/docs/policies/agreement?lang=en-US
+    * https://marketplace.firefox.com/developers/docs/policies/agreement?lang=en-US
 * /marketplace_privacy_policy
-  * https://marketplace.firefox.com/privacy-policy?lang=en-US
+    * https://marketplace.firefox.com/privacy-policy?lang=en-US
 * /marketplace_terms_of_use
-  * https://marketplace.firefox.com/terms-of-use?lang=en-US
+    * https://marketplace.firefox.com/terms-of-use?lang=en-US
 * /mozilla_privacy_policy
-  * https://www.mozilla.org/en-US/privacy/
+    * https://www.mozilla.org/en-US/privacy/
 * /websites_privacy_notice
-  * https://www.mozilla.org/en-US/privacy/websites/
+    * https://www.mozilla.org/en-US/privacy/websites/

--- a/thunderbird_privacy_policy/en-US.md
+++ b/thunderbird_privacy_policy/en-US.md
@@ -14,14 +14,14 @@ In this privacy policy, we talk about:
 * [Information Thunderbird Sends to Websites, Email Providers, and ISPs](#disclosed)
 * [Tracking and Cookies](#tracking)
 * [Data Practices for Interactive Product Features](#features), including
-  * [Addons](#addons),
-  * [Personas](#personas), and
-  * [Usage Statistics](#telemetry)
+    * [Addons](#addons),
+    * [Personas](#personas), and
+    * [Usage Statistics](#telemetry)
 * [What Mozilla Does to Secure Data](#security)
 * [Legal Process and Others Disclosures](#legal)
-  * [What and When We Share with Third Parties](#third-parties)
-  * [Transfer of Data to the U.S.](#stateside)
-  * [Mozilla’s Approach to Data Retention](#retention)
+    * [What and When We Share with Third Parties](#third-parties)
+    * [Transfer of Data to the U.S.](#stateside)
+    * [Mozilla’s Approach to Data Retention](#retention)
 * [How Mozilla Discloses Changes to this Policy](#changes)
 * [How to Contact Mozilla about this Policy](#contact)
 

--- a/websites_privacy_notice/en-US.md
+++ b/websites_privacy_notice/en-US.md
@@ -31,14 +31,14 @@ We may use cookies, clear GIFs, third party web analytics, device information, a
 {: #data-tools }
 
 * **Functionality**: We may use cookies, device information and IP addresses to enhance functionality of certain products, services, and communications. For example:
-  * Cookies are used to remember your Firefox language preference and Firefox add-ons. They also assist with user sign-in and authentication so you can bypass entering your passwords on certain Mozilla websites.  
-  * IP addresses are used to customize communications by language and country.  
-  * Device information such as country, language, operator and OEM, may be used to customize your experience on Firefox Marketplace and Webmaker.
+    * Cookies are used to remember your Firefox language preference and Firefox add-ons. They also assist with user sign-in and authentication so you can bypass entering your passwords on certain Mozilla websites.  
+    * IP addresses are used to customize communications by language and country.  
+    * Device information such as country, language, operator and OEM, may be used to customize your experience on Firefox Marketplace and Webmaker.
 
 * **Metrics**: Clear GIFs, cookies and third party services help us understand in the aggregate how users engage with our products, services, communications, websites, online campaigns, snippets, devices, and other platforms. We use:
-  * Google Analytics, which places a cookie on your device, to obtain metrics on how users engage with our websites.      This helps us to improve site content.  
-  * Optimizely, which places a cookie on your device, to help us test variations of web content.  This helps us offer     better web experiences to users.
-  * Flashtalking, which uses a clear GIF on our download Firefox page.  This helps us measure the effectiveness of our     advertising campaigns.
+    * Google Analytics, which places a cookie on your device, to obtain metrics on how users engage with our websites.      This helps us to improve site content.  
+    * Optimizely, which places a cookie on your device, to help us test variations of web content.  This helps us offer     better web experiences to users.
+    * Flashtalking, which uses a clear GIF on our download Firefox page.  This helps us measure the effectiveness of our     advertising campaigns.
 
 ---------------------------------------
 


### PR DESCRIPTION
GitHub allows 2 spaces of indentation but it’s officially invalid and the [Python-Markdown](https://pythonhosted.org/Markdown/) library defaults to 4 spaces. Let’s use 4 for consistency. No content changes. Tested on my local server.

@mikaland2 can you please merge this? Thanks!