### PR TITLE
Archive Persona Privacy Policy and ToS

### DIFF
--- a/persona_privacy/en-US.md
+++ b/persona_privacy/en-US.md
@@ -1,0 +1,100 @@
+# Privacy & Persona
+
+* We need your verified email address to register a Persona Account, but we don’t ask for other personal information.
+* Your email address is shared with sites you visit to help you sign in, but is never given to anyone without your express consent.
+* Mozilla collects some log analytics data from your use of the Persona service so that we may improve the Persona service. We store this data separately from your personal information, and we delete individual datapoints once we have aggregated the data into useful statistics.
+* We don’t sell your data or use ad networks on the Persona webpages or service.
+* In the future, Mozilla will seek to bring email providers into this system, at which point their privacy policies and terms of service will apply (if you use an email provided by them).
+* For the full text of our privacy practices and all the "legalese" and details, please read our privacy policy below.
+
+---------------------------------------
+
+# Persona Privacy Policy
+
+Last Updated: 06 March 2013
+{: datetime="2013-03-06" }
+
+This privacy policy explains to what extent Mozilla Corporation (*) ("Mozilla") collects and uses information about users of Persona ("Persona Service"), where such users use the Mozilla-created servers and client.
+
+## Definitions
+
+"**Personal Information**" is information that you provide to us that personally identifies you, such as your name, phone number, or email address. Except for your email address, Mozilla does not collect or require end-users of the Persona Service to furnish Personal Information.
+
+"**Non-Personal Information**" is information that cannot by itself be directly associated with a specific person or entity. Non-Personal Information includes but is not limited to your computer’s configuration and which web browser you use.
+
+"**Potentially Personal Information**" is information that is Non-Personal Information in and of itself but that could be used in conjunction with other information to personally identify you. For example, Uniform Resource Locators ("URLs") (the addresses of web pages) and Internet Protocol ("IP") addresses (the addresses of computers on the internet) can be Personal Information when combined with internet service provider ("ISP") records.
+
+"**Operational Data**" means data regarding a user’s usage of the Services, such as access log data (such as data about when people access the service and with what piece of software). Mozilla collects Operational Data to help us so that we can ensure that we have sufficient capacity to meet user needs and otherwise to help with the operations of the Services.
+
+"**Usage Statistics**" refers to the Non-Personal Information Mozilla will use to understand your use of the Service. Such information may include but is not limited to the amount of data you are storing with the service, the frequency with which you access the service, bandwidth utilization, user interaction data, and traffic shaping.
+
+For clarity, Usage Statistics and Operational Data from your use of the Persona Service are not stored with your Personal Information. We take steps to aggregate or delete Operational Data and Usage Statistics after we no longer need it, unless we are required by law to keep it longer.
+
+## Gathering, Use and Disclosure of Transmission Data
+
+### Account Information
+
+Before you are able to use Persona, you will be required to register. To register, the Persona Service will require the following Personal Information and Potentially Personal Information from you: an email address and password. Your email address is transferred to Mozilla using encryption called SSL. Your email address is used by us to provide you the services, such as allowing us to help you recover your account if you lose your password. Your password is transferred to Mozilla using SSL encryption but is only retained by Mozilla’s servers in an encrypted format (which means that it is not practically feasible to recover the password from this format).
+
+Once you have registered, your password is used to help prevent unauthorized access to your account.
+
+### Data Used to Provide the Services
+
+Mozilla receives and uses the following information for the purpose of providing and improving the Persona Service: IP address, email, date and time of accessing the Persona Service, and various operational data such as the type of client OS and browser version (which are also known as the user agent string).
+
+### Disclosure to Third Parties
+
+The Persona Service will disclose your verified email address to a Web site of your choosing, only after you have expressly consented to such disclosure. A Web site is allowed to request a verified email address, which results in you being prompted about the site’s request. After you have agreed, the service may remember your choice, so that you may remain signed-in on the site on subsequent visits.
+
+Mozilla will not otherwise knowingly disclose Personal Information or Potentially Personal Information to other third parties, except when required to do so, such as in order to comply with any law, regulation, or valid legal process, such as a search warrant, subpoena, statute, court order, or if necessary or appropriate to address an unlawful or harmful activity.
+
+### What Data is Analyzed by Mozilla?
+
+Mozilla uses the Usage Statistics to understand your use of the Persona Service, unless you opt-in to share more information with us for this purpose.
+
+### How Are the Usage Statistics Used?
+
+Mozilla will use the Usage Statistics gathered through the operation of the Persona Service to improve our products and services. By identifying aggregate patterns and trends in usage, Mozilla and its community are able to better design products and services to improve users’ experiences, both in terms of content and ease of use.
+
+### Where is the Operational Data Available?
+
+Mozilla is an open organization that believes in sharing as much information as possible about its products, its operations, and its associations with its wider community. As such, Persona Service users should expect that Mozilla will make all Usage Statistics publicly available at some point. However, any publicly available Usage Statistics will only be reported on an aggregate, anonymous basis. No Personal Information or Potentially Personal Information will be available in any of these public reports.
+
+### How to Disable or Opt-Out of Persona
+
+If at any time, you decide you no longer want to use the Persona Service, you may cancel your Persona Account by visiting https://persona.org/, signing in using any of your email addresses and your password, clicking the "edit" button, and clicking "remove" next to each of your email addresses. If you do not remember your password, you can use the email-verification-based password-reset feature to first recover access to your account, then delete it.
+
+### Other Disclosures
+
+In certain other limited situations, Mozilla may disclose your Personal Information, such as when necessary to protect our websites and operations (e.g., against attacks); to protect the rights, privacy, safety, or property of Mozilla or its users; to enforce our terms of service; and to pursue available legal remedies. Additionally, Mozilla may need to transfer Personal Information to an affiliate or successor in the event of a change of our corporate structure or status, such as in the event of a restructuring, sale, or bankruptcy.
+
+### Service Providers
+
+We work with third parties who provide services and content delivery networks and other services of an administrative nature. We may share information about you with such third parties for the purpose of enabling these third parties to provide such services.
+
+### Transfer of Data to the U.S.
+
+Mozilla is a global organization and operates in different countries. Privacy laws and common practices vary from country to country. Some countries may provide for less legal protection of your personal data; others may provide more legal protection. By using the Persona Service, you consent to the transfer of the information collected, as outlined by this Policy, to Mozilla in the United States, which may provide a lesser level of data protection than in your country of residence.
+
+### Data Retention
+
+We will retain any information collected for the period necessary to fulfill the purposes outlined in this Policy unless a longer retention period is required by law and/or regulations.
+
+### Privacy Policy Changes
+
+Mozilla may change this Privacy Policy from time to time. Each time you use the Persona Service the current version of this Privacy Policy will apply. Any and all changes will be reflected on this page. You should periodically check this page for any changes to the current policy. To make your review more convenient, we will post an effective date at the top of this page. Material changes will also be announced through the standard mechanisms through which Mozilla communicates with the Mozilla community. It is your responsibility to ensure that you understand the terms of this Privacy Policy.
+
+### What This Privacy Policy Doesn’t Cover
+
+This policy does not apply to other Mozilla websites, products, or services. It also does not apply to your use of third-party clients or use of non-Mozilla servers. If you choose to use a third-party Persona client or servers provided by an entity other than Mozilla, this policy does not apply and Mozilla assumes no liability whatsoever for such products or services.
+
+### For More Information
+
+You may request access, correction, or deletion of Personal Information or Potentially Personal Information, as permitted by law. We will seek to comply with such requests, provided that we have sufficient information to identify the Personal Information or Potentially Personal Information related to you. Any such requests or other questions or concerns regarding this Policy and Mozilla’s data protection practices should be addressed to:
+
+Mozilla Corporation<br>
+Attn: Legal Notices – Privacy<br>
+331 E. Evelyn Avenue<br>
+Mountain View, CA 94041<br>
+Phone: +1-650-903-0800<br>
+[Send us an email](https://www.mozilla.org/en-US/privacy/#contact)

--- a/persona_tos/en-US.md
+++ b/persona_tos/en-US.md
@@ -1,0 +1,63 @@
+# Persona Terms of Service — Overview
+
+* The Mozilla Persona service allows a logged-in user to verify that he is the owner of a certain email address.  Once the user has made this verification and uses that email address at websites utilizing the Mozilla Persona service, the website can request that Mozilla confirm that the user has verified the email address exists and is owned by him.
+* The Mozilla Persona service works with websites to confirm that a user has verified a certain email address and with email providers to make the initial user verification.  These Terms of Service apply to both the websites and the email providers who use Mozilla Persona.
+* You are responsible for the third party software or APIs that you use or have developed to access the Mozilla Persona Service. The Mozilla Persona service are provided “as is” and there are no warranties of any kind.
+* There are significant limits on Mozilla’s liability for any damages arising from your use of the Mozilla Persona service.
+
+---------------------------------------
+
+# Persona Terms of Service
+
+## Acceptance
+
+These Terms of Service (“TOS”) govern your use of the Mozilla Persona service (the “Services”). By accessing the materials and APIs necessary to use the Services, and by using the Services you are agreeing to abide by the terms and conditions described below.
+
+## Use of the Services as a Requesting Website or Email Provider
+
+To use the Services a website must include in their pages a JavaScript library provided by Mozilla and use the provided API to request a verified email address. If a user has chosen to  verify an email address as part of the Services, Mozilla will send a confirmation email to the email address.  When we receive a response from that email account or a confirmation from the email provider, we will store that verification and confirm to the user  that the verification was successful.  After that, if the user is logged into the Services and visits your website and you would like to request a verification of the that the email address, we will issue a verification to you..  The verification will confirm that this user had access at verification time to the specified email address.
+
+You may use the Services only for purposes that are permitted by (i) the TOS and (ii) the laws and regulations in your state and country and any other laws and regulations that apply to your use of the Services (including any laws regarding the export of data or software to and from the United States or other relevant countries).
+
+You agree not to:
+
+* engage in any activity that interferes with or disrupts the Services (or the servers and networks that are connected to the Services),
+* trade or resell the Services for any purpose, unless you have been specifically permitted to do so in writing by Mozilla, or
+* access (or attempt to access) the Services by any means other than the Mozilla Persona site itself (at browserid.org), official Mozilla-branded software (Firefox, Firefox for Mobile, and Firefox Home, referred to in this document as “Firefox Clients”), or third party software that utilizes APIs authorized and provided by Mozilla (“Third Party Clients”), unless you have been specifically allowed to do so in writing by Mozilla.
+  
+
+## Your Acknowledgments
+
+You acknowledge and agree that Mozilla has no responsibility for Third Party Clients and that you are solely responsible for your use of them.
+
+* Mozilla does not represent or imply that it endorses any Third Party Clients nor that it believes the operation of any Third Party Clients will be accurate, useful, or non-harmful.
+* Third Party Clients may have technical inaccuracies, may cause mistakes or errors, and may transmit, store, or otherwise manipulate data in a manner that you find objectionable. You are responsible for taking precautions to protect yourself and your computer systems in connection with the use of Third Party Clients.
+* Third Party Clients may be subject to additional terms and separate privacy policies and practices.  Mozilla’s privacy policy(ies) shall not apply with respect to data stored on, manipulated, or transmitted to or from Mozilla’s servers by means of your use of Third Party Clients.
+
+You also acknowledge and agree that:
+
+* Mozilla has the right to manage the Services to protect the rights and property of Mozilla and others and to facilitate the proper functioning of the Services, including disabling your account.
+* You will not use the Services for any purpose where an accurate verification of identity has critical or life-threatening consequences or has other significant or financial consequences such as in the context of financial services, banking, education, immigration, taxes, or other government functions, or healthcare.
+* Mozilla may discontinue or change the Services at its discretion without liability. If we discontinue or change the Services, we will announce it through Mozilla’s usual channels for such announcements such as blog posts and forums.
+
+## Proprietary Rights
+
+Mozilla does not grant you any intellectual property rights in the Services that are not specifically stated in this TOS.  For example, this TOS does not provide the right to use any of Mozilla’s copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.
+
+The Firefox Clients are distributed under and subject to the current version of the Mozilla Public License, located at https://www.mozilla.org/MPL.
+
+## Updates to the Terms
+
+Mozilla may update this TOS from time to time, for example to address a new feature of the Services or to clarify a provision. The updated TOS will be posted on the Mozilla Persona site. If the changes are substantive, we will announce the update through Mozilla’s usual channels for such announcements such as blog posts and forums. Your continued use of the Services after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of this page. These terms may not be modified or cancelled without Mozilla’s written agreement.
+
+## Disclaimer of Warranty
+
+**The Services are provided “as is” with all faults. To the extent permitted by law, Mozilla, its distributors, contributors, and licensors hereby disclaim all warranties, whether express or implied, including without limitation warranties that the Services are free of defects, merchantable, fit for a particular purpose, and non-infringing. You bear the entire risk as to selecting the Services for your purposes and as to the quality and performance of the Services, including without limitation the risk that your User Data is deleted or corrupted or that someone else uses your username and password to access confirmations of your identity. This limitation will apply notwithstanding the failure of essential purpose of any remedy. Some jurisdictions do not allow the exclusion or limitation of implied warranties, so this disclaimer may not apply to you.**
+
+## Limitation of Liability
+
+**Except as required by law, Mozilla, its distributors, contributors, and licensors, will not be liable for any indirect, special, incidental, consequential, or exemplary damages arising out of or in any way relating to this TOS or the use of or inability to use the Services, including without limitation damages for loss of goodwill, work stoppage, lost profits, loss of data, and computer failure or malfunction, even if advised of the possibility of such damages and regardless of the theory (contract, tort, or otherwise) upon which such claim is based. The collective liability of Mozilla, its distributors, contributors, and licensors under this Agreement will not exceed $500 (five hundred dollars). Some jurisdictions do not allow the exclusion or limitation of incidental, consequential, or special damages, so this exclusion and limitation may not apply to you.**
+
+## Miscellaneous
+
+This TOS constitutes the entire agreement between you and Mozilla Corporation (“Mozilla” or we) concerning the Services. These terms are governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions.  The United Nations Convention on Contracts for the International Sale of Goods is expressly disclaimed.  If any portion of these terms is held to be invalid or unenforceable, the remaining portions will remain in full force and effect. In the event of a conflict between a translated version of these terms and the English language version, the English language version shall control.


### PR DESCRIPTION
Mozilla Persona is now deprecated, and the related pages are being removed from www.mozilla.org in [Bug 1238851](https://bugzilla.mozilla.org/show_bug.cgi?id=1238851). This pull request adds the Persona Privacy Policy and Terms of Service to legal-docs for archival purpose.