### PR TITLE
Add package.json so we can install via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firefox Marketplace Legal Documents
 
-This repository contains all legal documents and their applicable translations. The repository is organize within the `docs/` directory, where each subdirectory represents a single legal document. Within a document directory is a series of markdown files, each named for the language the document is written in. For instance, `docs/privacy_policy/de.md` is the German version of the Marketplace privacy policy.
+This repository contains all legal documents and their applicable translations. The repository is organized within the `docs/` directory, where each subdirectory represents a single legal document. Within a document directory is a series of markdown files, each named for the language the document is written in. For instance, `docs/privacy_policy/de.md` is the German version of the Marketplace privacy policy.
 
 ## Editing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "legal-docs",
+  "description": "This repository contains all legal documents and their applicable translations.",
+  "version": "1.0.0",
+  "author": "Mozilla (https://mozilla.com/)",
+  "bugs": {
+    "url": "https://github.com/mozilla/legal-docs/issues"
+  },
+  "homepage": "https://github.com/mozilla/legal-docs#readme",
+  "keywords": [],
+  "license": "MPL-2.0",
+  "repository": "mozilla/legal-docs"
+}


### PR DESCRIPTION
Adding a package.json file so we can quickly integrate the legal-docs with out project.

**Usage:**
```bash
$ npm i mozilla/legal-docs -D
```

This will clone the https://github.com/mozilla/legal-docs repo and put it in our ./node_modules/ directory so we can easily convert our **Terms of Use** and **Privacy Notice** docs from Markdown to HTML, etc.