### PR TITLE
Assign multiple IDs properly on Referral and Campaign Tracking

### DIFF
--- a/firefox_privacy_notice/en-US.md
+++ b/firefox_privacy_notice/en-US.md
@@ -66,8 +66,7 @@ Firefox automatically connects to us and our service providers to provide update
 
 	Search suggestions is a feature to help you to find out common phrases that other people have searched for. These search suggestions are offered by your Default Search Engines (such as Google, Yahoo, etc.) and not by Firefox. If you enable this feature, and your Default Search Engine supports suggestions, Firefox may send the terms you type in the Awesome Bar or Search Bar to your Default Search Engine to retrieve suggestions, and is governed by the applicable Privacy Policy from your Default Search Engine. You can [learn more about Search Suggestions here](https://support.mozilla.org/kb/use-popular-search-suggestions-firefox-search-bar) and how to enable or disable it.
 
-* **Referral and Campaign Tracking**
-{: #thirdparty } {: #referraltracking }
+* **Referral and Campaign Tracking**{: #thirdparty } ** **{: #referraltracking }
 
 	To help understand and improve our marketing campaigns, Firefox may send “Referral Data” such as the website domain or advertising campaign that referred you to download and install Firefox.
  


### PR DESCRIPTION
Work around an issue found in [Bug 1338331](https://bugzilla.mozilla.org/show_bug.cgi?id=1338331) by inserting an empty `<strong>` element and assign another ID on it.