### PR TITLE
Update firefox_cloud_services_PrivacyNotice/cs.md

### DIFF
--- a/firefox_cloud_services_PrivacyNotice/cs.md
+++ b/firefox_cloud_services_PrivacyNotice/cs.md
@@ -9,13 +9,13 @@ Staráme se o ochranu vašeho soukromí. Když Firefox Cloud Services (dále jen
 
 Zasílat nám můžete různé typy dat v závislosti na tom, jaké Služby využíváte.
 
-* **E-mailová adresa**: Pokud si založíte účet Firefox, obdržíte e-mail s heslem. Navíc můžete volitelně nastavit profilový obrázek nebo použít Gravatar (v takovém případě poskytneme vaši e-mailovou adresu společnosti Gravatar, abychom získali váš profilový obrázek).
+* **E-mailová adresa**: Pokud si založíte účet Firefoxu, obdržíme vaši e-mailovou adresu a hash vašeho hesla. Navíc můžete volitelně nastavit profilový obrázek nebo použít Gravatar (v takovém případě poskytneme vaši e-mailovou adresu společnosti Gravatar, abychom získali váš profilový obrázek).
 
-* **Synchronizace**: Pokud Synchronizaci aktivujete, obdržíme v šifrovaném formátu data, která mezi zařízeními synchronizujete (která mohou zahrnovat karty Firefox, doplňky, hesla, záložky, historii a předvolby).  Ačkoliv je nemůžeme dešifrovat, měli byste použít silné heslo pro zabránění neoprávněnému přístupu k vašim synchronizovaným datům.  Ukládáme rovněž informace o operačním systému vašeho zařízení a verzi Firefox, abychom vám mohli zobrazit zařízení, která jsou s vašim účtem synchronizována. 
+* **Sync**: Pokud Sync aktivujete, obdržíme v šifrovaném formátu data, která mezi zařízeními synchronizujete (která mohou zahrnovat panely Firefoxu, doplňky, hesla, záložky, historii a předvolby). Ačkoliv je nemůžeme dešifrovat, měli byste použít silné heslo pro zabránění neoprávněnému přístupu k vašim synchronizovaným datům. Ukládáme rovněž informace o operačním systému vašeho zařízení a verzi Firefoxu, abychom vám mohli zobrazit zařízení, která jsou s vašim účtem synchronizována. 
 
-* **Údaje o místě**: Pro bezpečnostní účely ukládáme adresy IP, z nichž přistupujete k vašemu účtu Firefox pro přibližné stanovení města a země.  Tato data používáme k zasílání e-mailových varování, pokud zjistíme podezřelou činnost, jako například přihlášení k účtu z jiných míst.
-    
-	* **Najít mé zařízení**: Pokud aktivujete funkci Najít mé zařízení, zjistíme přibližné místo vašeho zařízení pouze pokud se přihlásíte ke svému účtu Firefox a pokud nás výslovně požádáte o vyhledání připojeného zařízení. Pokud jste přihlášeni, uvidíte poslední známé místo vašeho zařízení na mapě. Tato místa pravidelně vymazáváme a další místa nebudeme shromažďovat, dokud nás o to nepožádáte.
+* **Údaje o místě**: Pro bezpečnostní účely ukládáme IP adresy, z nichž přistupujete k vašemu účtu Firefoxu pro přibližné stanovení města a země. Tato data používáme k zasílání e-mailových varování, pokud zjistíme podezřelou činnost, jako například přihlášení k účtu z jiných míst.
+
+	* **Najít mé zařízení**: Pokud aktivujete funkci Najít mé zařízení, zjistíme přibližné místo vašeho zařízení pouze pokud se přihlásíte ke svému účtu Firefoxu a pokud nás výslovně požádáte o vyhledání připojeného zařízení. Pokud jste přihlášeni, uvidíte poslední známé místo vašeho zařízení na mapě. Tato místa pravidelně mažeme a další místa nebudeme shromažďovat, dokud nás o to nepožádáte.
 
 ---------------------------------------
 


### PR DESCRIPTION
- účet Firefox -> účet Firefoxu (declension)
- obdržíte e-mail s heslem -> obdržíme vaši e-mailovou adresu a hash vašeho hesla (the original would mean "you receive email and password")
- Synchronizace -> Sync (name of the service, we do not translate that)
- karty -> panely (terminology)
- vymazáváme -> mažeme (grammar)

Who writes these things??? Cannot they at least look at the product or related websites? I know we do not have any style guide, but the dictionary is there https://wiki.mozilla.org/L10n:Teams:cs in the L10n kit, and most of these changes cannot be handled by a style guide. Can the agency just let us know when they make the update and ask for a "terminology" review, if they do not want to find it out themselves?