### PR TITLE
Fix Italian Firefox Privacy

### DIFF
--- a/firefox_privacy_notice/it.md
+++ b/firefox_privacy_notice/it.md
@@ -1,157 +1,156 @@
-﻿## <span class="privacy-header-firefox">Firefox - </span> <span class="privacy-header-policy">Avviso sulla privacy</span>
+## <span class="privacy-header-firefox">Firefox - </span> <span class="privacy-header-policy">Avviso sulla privacy</span>
 
-*Effettivo dal  28 settembre 2017*
+*Effettivo dal 28 settembre 2017*
 {: datetime="2017-09-28" }
 
-## In Mozilla, crediamo nel fatto che la privacy sia fondamentale per un uso sano di Internet.
+## In Mozilla crediamo nel fatto che la privacy sia fondamentale per un uso sano di Internet.
 
-Ecco perché abbiamo realizzato Firefox e tutti i nostri prodotti: per garantirvi  maggior controllo sulle informazioni condivise online e  su quelle che condividete con noi. Ci sforziamo di raccogliere solo quello che è necessario per migliorare Firefox per tutti
+Ecco perché abbiamo realizzato Firefox e tutti i nostri prodotti: per garantirvi maggior controllo sulle informazioni condivise online e su quelle che condividete con noi. Ci impegniamo a raccogliere solo quello che è necessario per migliorare Firefox per tutti.
 
-In questo Avviso sulla privacy, illustreremo quali sono i dati che  Firefox condivide e vi spiegheremo come usare le impostazioni per condividere ancora meno dati. Aderiamo, inoltre, alle pratiche  descritte nell'informativa sulla  [privacy di Mozilla](https://www.mozilla.org/privacy/) per quanto riguarda il modo in cui riceviamo, trattiamo e condividiamo le informazioni che raccogliamo da Firefox.
+In questo Avviso sulla privacy illustreremo quali sono i dati che Firefox condivide e spiegheremo come usare le impostazioni per condividere ancora meno dati. Ci atteniamo, inoltre, alle pratiche descritte nell’informativa sulla [privacy di Mozilla](https://www.mozilla.org/privacy/) per quanto riguarda il modo in cui riceviamo, trattiamo e condividiamo le informazioni che raccogliamo da Firefox.
 
 ## Per impostazione predefinita, Firefox condivide dati al fine di:
 
-### migliorare le prestazioni e la stabilità per gli utenti, ovunque si trovino. {: #health-report }
+### Migliorare le prestazioni e la stabilità per gli utenti, ovunque si trovino. {: #health-report }
 
-* __Dati sull’interazione__: Firefox ci invia dati sulle vostre interazioni con Firefox (ad es., numero di schede e schermate aperte; numero di pagine web visitate, numero e tipo di componenti aggiuntivi Firefox installati; e lunghezza della sessione) e sulle funzioni Firefox offerte da Mozilla o dai nostri partner (es. interazione con le funzioni di ricerca di Firefox e riferimenti di partner di ricerca).  
+* __Dati sull’interazione__: Firefox ci invia dati sulle vostre interazioni con il browser (ad esempio: numero di schede e schermate aperte, numero di pagine web visitate, numero e tipo di componenti aggiuntivi installati, lunghezza della sessione) e sulle funzioni offerte da Mozilla o dai nostri partner (ad esempio: interazione con le funzioni di ricerca di Firefox e riferimenti di partner di ricerca).
 
-* __Dati tecnici__: Firefox ci invia dati sulla vostra versione di Firefox e sulla lingua usata; sul sistema operativo del dispositivo e sulla configurazione hardware, sulla memoria, su informazioni di base su guasti ed errori; sul risultato di processi automatici quali aggiornamenti, sicurezza nella navigazione e attivazione.  Quando Firefox ci invia i dati, il vostro indirizzo IP viene temporaneamente raccolto quale parte dei log del nostro server.  
+* __Dati tecnici__: Firefox ci invia dati sulla versione di Firefox e sulla lingua usata; sul sistema operativo del dispositivo e sulla configurazione hardware, sulla memoria, su informazioni di base su arresti anomali ed errori; sul risultato di processi automatici quali aggiornamenti, servizio di safebrowing e attivazione. Quando Firefox ci invia i dati, il vostro indirizzo IP viene temporaneamente raccolto quale parte dei log del nostro server.
 
-Leggere la documentazione di telemetria per [Desktop](http://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](http://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), oppure per [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o imparare come eseguire [l’opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) di questa raccolta di dati.
+È possibile consultare la documentazione di telemetria per [Desktop](http://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](http://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), oppure per [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o scoprire come [non partecipare](https://support.mozilla.org/kb/send-performance-data-improve-firefox) a questa raccolta di dati.
 {: #telemetry }
 
 ### Impostare un fornitore di servizi di ricerca predefinito {: #defaultsearch }
 
-* __Dati sulla posizione__:  quando usate Firefox per la prima volta, il motore di ricerca userà il vostro indirizzo IP per impostare il fornitore di servizi di ricerca predefinito in base al vostro Paese.  [Altre informazioni](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
+* __Dati sulla posizione__: quando usate Firefox per la prima volta, il motore di ricerca userà il vostro indirizzo IP per impostare il fornitore di servizi di ricerca predefinito in base al vostro Paese. [Ulteriori informazioni](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
 
-### Suggerire contenuto pertinente 
+### Suggerire contenuti rilevanti
 
-Firefox visualizza contenuto come gli “Snippets” (messaggi da parte di Mozilla) e Siti Top (siti web suggeriti da Mozilla per nuovi utenti Firefox).
+Firefox visualizza contenuti come gli “Snippets” (messaggi da parte di Mozilla) e Siti principali (siti web suggeriti da Mozilla per nuovi utenti Firefox).
 
-* __Dati sulla posizione__: Firefox usa il vostro indirizzo IP per suggerire contenuto pertinente basato nel vostro Paese.
+* __Dati sulla posizione__: Firefox usa il vostro indirizzo IP per suggerire contenuti rilevanti in base al vostro Paese.
 
-* __Dati tecnici e di interazione__: Firefox ci invia dati quali  posizione,  dimensioni e collocazione di contenuto che suggeriamo, nonché dati di base sulle vostre interazioni con il contenuto suggerito di Firefox. Questo include il numero di volte che il contenuto suggerito viene visualizzato o le volte che si fa clic sul contenuto.
+* __Dati tecnici e di interazione__: Firefox ci invia dati quali posizione, dimensioni e collocazione dei contenuti che suggeriamo, nonché dati di base sulle vostre interazioni con i contenuti suggeriti di Firefox. Questo include il numero di volte che un contenuto suggerito viene visualizzato o le volte che si fa clic sul contenuto.
 
-* __Dati delle pagine web per Snippets__: Quando si sceglie di fare clic su un link Snippet, si possono ricevere dati sul link seguito. Queste informazioni non sono associate ad altre informazioni su di voi. [Altre informazioni](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
+* __Dati delle pagine web per Snippets__: quando si sceglie di fare clic su un link Snippet, si possono ricevere dati sul link seguito. Queste informazioni non sono associate ad altre informazioni personali. [Ulteriori informazioni](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
 {: #snippets }
 
 ### Migliorare la sicurezza per gli utenti, ovunque si trovino {: #security }
 
-* __Dati tecnici per aggiornamenti__: Le versioni desktop di Firefox cercano periodicamente aggiornamenti connettendosi ai server di Mozilla. La vostra versione di Firefox, la lingua e il sistema operativo del dispositivo sono usati per applicare i corretti aggiornamenti. Le versioni  mobili di Firefox possono connettersi ad un altro servizio se se ne usa uno per scaricare e installare Firefox. [Altre informazioni](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
+* __Dati tecnici per aggiornamenti__: le versioni desktop di Firefox cercano periodicamente aggiornamenti collegandosi ai server di Mozilla. La vostra versione di Firefox, la lingua e il sistema operativo del dispositivo sono usati per applicare i corretti aggiornamenti. Le versioni mobili di Firefox possono connettersi a un altro servizio se utilizzato inizialmente per scaricare e installare Firefox. [Ulteriori informazioni](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
 {: #auto-updates }
 
-* __Dati tecnici per l’elenco di blocco dei componenti aggiuntivi __: Firefox per desktop e Android si connettono periodicamente a Mozilla per proteggervi e proteggere altri da componenti aggiuntivi dannosi.  La versione e la lingua di Firefox, il sistema operativo del dispositivo e l’elenco di componenti aggiuntivi installati sono necessari per applicare e aggiornare l’elenco di blocco di componenti aggiuntivi [Altre informazioni](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/). 
+* __Dati tecnici per l’elenco di blocco dei componenti aggiuntivi__: Firefox per desktop e Android si connettono periodicamente a Mozilla per proteggere gli utenti da componenti aggiuntivi dannosi. La versione e la lingua di Firefox, il sistema operativo del dispositivo e l’elenco di componenti aggiuntivi installati sono necessari per applicare e aggiornare l’elenco di blocco di componenti aggiuntivi [Ulteriori informazioni](https://blog.mozilla.org/addons/how-to-opt-out-of-add-on-metadata-updates/).
 
-* __Pagina web e dati tecnici per il servizio Google Safe Browsing __: Per aiutare a proteggervi da download dannosi,  Firefox invia informazioni di base su download sconosciuti al servizio Google Safe Browsing, includendo il nome del file e l’URL da cui è stato scaricato.  
+* __Pagina web e dati tecnici per il servizio Google Safe Browsing__: per aiutare a proteggervi da download dannosi, Firefox invia informazioni di base su download sconosciuti al servizio Google Safe Browsing, includendo il nome del file e l’URL da cui è stato scaricato.
 
-    [Altre informazioni](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) oppure leggere le [Norme sulla privacy di Google](https://www.google.com/policies/privacy/). L’opt out impedisce a Firefox di avvertirvi sul pericolo di siti web o file scaricati potenzialmente illegali o dannosi.
+  [Ulteriori informazioni](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) oppure leggere le [Norme sulla privacy di Google](https://www.google.com/policies/privacy/). L’opt-out impedisce a Firefox di avvertirvi sul pericolo di siti web o file scaricati potenzialmente illegali o dannosi.
 
-* __Pagina web page e dati tecnici per le Autorità di certificazione__: Quando si visita un sito web sicuro (di solito identificato con un URL che inizia con "HTTPS"), Firefox convalida il certificato del  [sito web](https://support.mozilla.org/kb/secure-website-certificate). Questa procedura può includere l’invio, da parte di Firefox, di determinate informazioni sul sito web all’Autorità di certificazione identificata dal sito web.  
+* __Pagina web page e dati tecnici per le Autorità di certificazione__: quando si visita un sito web sicuro (di solito identificato con un URL che inizia con “HTTPS”), Firefox convalida il certificato del [sito web](https://support.mozilla.org/kb/secure-website-certificate). Questa procedura può includere l’invio, da parte di Firefox, di determinate informazioni sul sito web all’Autorità di certificazione identificata dal sito web.
 
-    L’opt out aumenta il rischio di intercettazione delle vostre informazioni riservate. [Altre informazioni](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab).
+  L’opt-out aumenta il rischio di intercettazione delle vostre informazioni riservate. [Ulteriori informazioni](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab).
 
 ### Riportare gli arresti anomali {: #crash-reporter }
-Per impostazione predefinita, sulle versioni  desktop di Firefox, vi chiederemo di condividere una segnalazione di arresto con informazioni più dettagliate con Mozilla: potrete sempre scegliere di rifiutare.
+Per impostazione predefinita, sulle versioni desktop di Firefox, vi chiederemo di condividere una segnalazione di arresto con informazioni più dettagliate con Mozilla: potrete sempre scegliere di rifiutare.
 
-* __Dati di natura delicata__:  Le segnalazioni di di arresto includono un ‘dump file’ del contenuto della memoria di Firefox al momento dell’arresto, che potrebbero includere dati di natura riservata o che permettono di identificarvi.
+* __Dati di natura delicata__: le segnalazioni di arresto includono un “dump file” del contenuto della memoria di Firefox al momento dell’arresto, che potrebbero includere dati di natura riservata o che permettono di identificarvi.
 
-* __Dati delle pagine web__:  Le segnalazioni di arresto includono l’URL attivo al momento dell’arresto.
+* __Dati delle pagine web__: le segnalazioni di arresto includono l’URL attivo al momento dell’arresto.
 
-* __Dati tecnici__:  Le segnalazioni di arresto includono dati sul motivo dell’arresto di Firefox, lo stato della memoria del dispositivo e dell’esecuzione  durante l’arresto.
+* __Dati tecnici__: le segnalazioni di arresto includono dati sul motivo dell’arresto di Firefox, lo stato della memoria del dispositivo e dell’esecuzione durante l’arresto.
 
-Leggere la documentazione completa[qui](https://firefox-source-docs.mozilla.org/toolkit/crashreporter/crashreporter/index.html).
+La documentazione completa è disponibile in [questa pagina](https://firefox-source-docs.mozilla.org/toolkit/crashreporter/crashreporter/index.html).
 
-### Calcolo e supporto del nostro marketing
+### Misurazioni e supporto delle campagne di marketing
 
-* __Campagna e dati di riferimento__: Questo aiuta Mozilla a comprendere l’efficacia delle nostre campagne di marketing.
+* __Campagna e dati di riferimento__: questo aiuta Mozilla a comprendere l’efficacia delle nostre campagne di marketing.
 {: #referraltracking }
 
-    _Su desktop_: Per impostazione predefinita, Firefox invia dati a Mozilla HTTP che potrebbero essere inclusi nell’installer di Firefox.  Questo ci consente di determinare il dominio o la campagna pubblicitaria del sito web (se esistenti) che conduce alla nostra pagina di download. Leggere la [documentazione](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) orppure[eseguire l’opt out](https://support.mozilla.org/kb/desktop-privacy) before installation.
+  _Su desktop_: per impostazione predefinita, Firefox invia dati a Mozilla tramite HTTP che potrebbero essere inclusi nell’installer di Firefox. Questo ci consente di determinare il dominio o la campagna pubblicitaria del sito web (se esistenti) che conduce alla nostra pagina di download. Leggere la [documentazione](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) oppure [eseguire l’opt-out](https://support.mozilla.org/kb/desktop-privacy) prima dell’installazione.
 
-    _Su iOS e  Android_: Per impostazione predefinita, Firefox invia dati sulle campagne pubblicitarie mobili ad  Adjust, il nostro rivenditore di analytics, che ha la propria [informativa sulla privacy](https://www.adjust.com/privacy_policy/).  I dati per le campagne mobili includono: ID pubblicità Google, indirizzo IP, timestamp, Paese, lingua/impostazioni locali, sistema operativo e versione dell’app. Leggere la [documentazione](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
+  _Su iOS e Android_: per impostazione predefinita, Firefox invia dati sulle campagne pubblicitarie mobili ad Adjust, il nostro fornitore di dati analytics, che ha la propria [informativa sulla privacy](https://www.adjust.com/privacy_policy/). I dati per le campagne mobili includono: ID pubblicità Google, indirizzo IP, timestamp, Paese, lingua/impostazioni locali, sistema operativo e versione dell’app. Leggere la [documentazione](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
 {: #thirdparty }
 
-* __Dati tecnici e di interazione__: 
+* __Dati tecnici e di interazione__:
 
-    _Su iOS e  Android_: Per impostazione predefinita, Firefox invia dati sulle funzioni usate in Firefox a Leanplum, il nostro fornitore di mobile marketing, che ha la propria [informativa sulla privacy](https://www.leanplum.com/privacy/).  Questi dati ci consentono di eseguire test su diverse funzioni ed esperienze, nonché di fornire messaggi e consigli personalizzati per migliorare la vostra esperienza di Firefox.
+  _Su iOS e Android_: per impostazione predefinita, Firefox invia dati sulle funzioni usate in Firefox a Leanplum, il nostro fornitore di mobile marketing, che ha la propria [informativa sulla privacy](https://www.leanplum.com/privacy/). Questi dati ci consentono di eseguire test su diverse funzioni ed esperienze, nonché di fornire messaggi e consigli personalizzati per migliorare la vostra esperienza di Firefox.
 
-    Leggere la documentazione per [iOS](https://github.com/mozilla-mobile/firefox-ios/blob/master/MMA.md) o [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/mma.html), oppure imparate a [disattivare questa funzione](https://support.mozilla.org/kb/send-anonymous-usage-data-firefox-mobile-devices).
+  Consultare la documentazione per [iOS](https://github.com/mozilla-mobile/firefox-ios/blob/master/MMA.md) o [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/mma.html), oppure scoprire come [disattivare questa funzione](https://support.mozilla.org/kb/send-anonymous-usage-data-firefox-mobile-devices).
 
 ---
 
-## Se usate queste funzioni,  Firefox condividerà dati per fornire funzionalità:  {: #optional-features }
+## Se usate queste funzioni, Firefox condividerà dati per fornire le funzionalità: {: #optional-features }
 
 ### Ricerca
 
-Si può eseguire ricerche direttamente da diversi punti di  Firefox, incluse Awesome Bar e la barra di ricerca o su una Nuova scheda.  _Mozilla non riceve le vostre query di ricerca._ I dati delle query sono inviati al fornitore di servizi di ricerca, che ha la propria informativa sulla privacy  
+È possibile eseguire ricerche in Firefox in diversi punti, inclusi la barra degli indirizzi, la barra di ricerca e la pagina Nuova scheda. _Mozilla non riceve le vostre richerche._ I dati delle richerche sono inviati al fornitore di servizi di ricerca, che ha la propria informativa sulla privacy.
 
-* __Suggerimenti di ricerca__: Per impostazione predefinita, Firefox invia le query al vostro fornitore di servizi di ricerca per aiutarvi a scoprire frasi comuni usate nelle ricerche da altri, per migliorare la vostra esperienza. Questi dati non saranno inviati se il vostro fornitore di servizi di ricerca selezionato non supporta i suggerimenti di ricerca.
-{: #searchsuggestions } 
+* __Suggerimenti di ricerca__: per impostazione predefinita, Firefox invia le richieste al vostro fornitore di servizi di ricerca per aiutarvi a scoprire frasi comuni usate nelle ricerche da altri, per migliorare la vostra esperienza. Questi dati non saranno inviati se il vostro fornitore di servizi di ricerca selezionato non supporta i suggerimenti di ricerca.
+{: #searchsuggestions }
 
-    [Altre informazioni](https://support.mozilla.org/kb/use-popular-search-suggestions-firefox-search-bar), che includono come disattivare questa funzione.
+  [Ulteriori informazioni](https://support.mozilla.org/kb/use-popular-search-suggestions-firefox-search-bar), che includono come disattivare questa funzione.
 
-### Account Firefox 
+### Account Firefox
 
-* __ Dati degli account Firefox __: Mozilla riceve il vostro indirizzo e-mail e una hash della vostra password quando create un account Firefox.  Potete scegliere di includere un nome visualizzato o un'immagine profilo.  Il vostro indirizzo e-mail viene inviato al nostro rivenditore e-mail, SalesForce Marketing Cloud, che ha la propria  [informativa sulla privay](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Se usate l’account Firefox per accedere ad altri siti o servizi web (come AMO o Pocket), riceveremo il timestamp del vostro login a questi servizi. 
+* __ Dati degli account Firefox__: Mozilla riceve il vostro indirizzo email e una hash della vostra password quando create un account Firefox. Potete scegliere di includere un nome visualizzato o un’immagine per il profilo. Il vostro indirizzo email viene inviato al nostro rivenditore email, SalesForce Marketing Cloud, che ha la propria [informativa sulla privay](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Se usate l’account Firefox per accedere ad altri siti o servizi web (come AMO o Pocket), riceveremo il timestamp del vostro accesso a questi servizi.
 
-* __Dati sulla posizione__: Per motivi di sicurezza , memorizziamo l’indirizzo IP che usate per accedere al vostro account Firefox per avere i dati approssimati della vostra città e del vostro Paese.  Utilizziamo questi dati per inviare avvisi via e-mail  nel caso di individuazione di attività sospette, tipo login all’account da altre località.
+* __Dati sulla posizione__: per motivi di sicurezza memorizziamo l’indirizzo IP che usate per accedere al vostro account Firefox per avere i dati approssimati della vostra città e del vostro Paese. Utilizziamo questi dati per inviare avvisi via e-mail nel caso di individuazione di attività sospette, come accessi all’account da altre località.
 
-* __Dati sull’interazione__: Riceviamo dati quali visite al  sito web e alle preferenze di menu degli account Firefox e relative interazioni, oltre alle interazioni con i messaggi di benvenuto, e-mail e SMS. [Leggere altre informazioni](https://www.mozilla.org/privacy/websites/) sulle pratiche sui dati per siti web ed e-mail.  
+* __Dati sull’interazione__: riceviamo dati quali visite al sito web e alle preferenze di menu degli account Firefox e relative interazioni, oltre alle interazioni con i messaggi di benvenuto, email e SMS. [Ulteriori informazioni](https://www.mozilla.org/privacy/websites/) sulle pratiche sui dati per siti web ed email.
 
-* __Dati tecnici__: Per visualizzare i dispositivi sincronizzati al vostro account Firefox e per la funzionalità, memorizziamo il sistema operativo del dispositivo, il browser e la sua versione, il timestamp, le impostazioni locali e le stesse informazioni riguardanti i dispositivi connessi all’account.  
+* __Dati tecnici__: per visualizzare i dispositivi sincronizzati al vostro account Firefox e per la funzionalità, memorizziamo il sistema operativo del dispositivo, il browser e la sua versione, il timestamp, le impostazioni locali e le stesse informazioni riguardanti i dispositivi connessi all’account.
 
-Leggere la [full documentazione](https://github.com/mozilla/fxa-auth-server/blob/master/docs/metrics-events.md) o [altre informazioni](https://support.mozilla.org/kb/access-mozilla-services-firefox-accounts), incluso come [eliminare il vostro account](https://support.mozilla.org/kb/how-do-i-delete-my-firefox-account).
+Leggere la [documentazione completa](https://github.com/mozilla/fxa-auth-server/blob/master/docs/metrics-events.md) o [ulteriori informazioni](https://support.mozilla.org/kb/access-mozilla-services-firefox-accounts), incluso come [eliminare il vostro account](https://support.mozilla.org/kb/how-do-i-delete-my-firefox-account).
 
-### Dati di Firefox  Sync {: #sync }
+### Dati di Firefox Sync {: #sync }
 
-* __Dati  sincronizzati__: Se si attiva Sync, Mozilla riceverà le informazioni che avete sincronizzato su tutti i dispositivi in forma crittografata. Le informazioni possono includere schede Firefox, componenti aggiuntivi, password, informazioni di pagamento compilate automaticamente, segnalibri, cronologia e preferenze.  Eliminando il vostro account Firefox, eliminerete anche il  relativo contenuto in Firefox Sync. Potete anche leggere la  [documentazione](http://moz-services-docs.readthedocs.io/en/latest/sync/).
-  
-* __Dati tecnici e di interazione__: Se attivate Sync, Firefox invierà periodicamente informazioni di base usando Telemetry sui tentativi più recenti di sincronizzazione dei vostri dati, riusciti o no, e sul tipo di dispositivo che avete tentato di sincronizzare. Potete anche leggere la  [documentazione](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html).
+* __Dati sincronizzati__: se si attiva Sync, Mozilla riceverà le informazioni che avete sincronizzato su tutti i dispositivi in forma crittografata. Le informazioni possono includere schede di Firefox, componenti aggiuntivi, password, informazioni di pagamento compilate automaticamente, segnalibri, cronologia e preferenze. Eliminando il vostro account Firefox, eliminerete anche il relativo contenuto in Firefox Sync. Potete anche leggere la [documentazione](http://moz-services-docs.readthedocs.io/en/latest/sync/).
 
-[Altre informazioni](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), incluse le istruzioni per attivare o disattivare la sincronizzazione.
+* __Dati tecnici e di interazione__: se attivate Sync, Firefox invierà periodicamente informazioni di base usando Telemetry sui tentativi più recenti di sincronizzazione dei vostri dati, riusciti o falliti, e sul tipo di dispositivo che avete tentato di sincronizzare. Potete anche leggere la [documentazione](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html).
 
-### Posizione{: #location-services }
+[Ulteriori informazioni](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), incluse le istruzioni per attivare o disattivare la sincronizzazione.
 
-* __Dati sulla posizione al servizio di geolocalizzazione di Google__: Firefox chiede sempre, prima di determinare e condividere la vostra posizione con un sito web che la richiede (ad esempio, se un sito web di mappe ha bisogno della vostra posizione per fornire direzioni).  Per determinare la posizione, Firefox può usare le funzioni di: sistema di geolocalizzazione, reti Wi-fi , ripetitori per cellulari o indirizzo IP e può inviare questi dati al servizio di geolocalizzazione di Google, che ha la sua [informativa sulla  privacy](https://www.google.com/privacy/lsf.html).
+### Posizione {: #location-services }
 
-[Altre informazioni](https://www.mozilla.org/firefox/geolocation/).
+* __Dati sulla posizione al servizio di geolocalizzazione di Google__: Firefox chiede sempre l’autorizzazione prima di determinare e condividere la vostra posizione con un sito web che la richiede (ad esempio, se un sito web di mappe ha bisogno della vostra posizione per fornire direzioni). Per determinare la posizione, Firefox può usare le funzioni di: sistema di geolocalizzazione, reti Wi-fi, ripetitori per cellulari o indirizzo IP e può inviare questi dati al servizio di geolocalizzazione di Google, che ha la sua [informativa sulla privacy](https://www.google.com/privacy/lsf.html).
+
+[Ulteriori informazioni](https://www.mozilla.org/firefox/geolocation/).
 
 ### Firefox Screenshots {: #screenshots }
 
-* __Caricamento di schermate catturate__: Le schermate catturate che scegliete di caricare vengono inviate a Mozilla e memorizzate per il periodo limitato indicato, che potrete modificare.  Possiamo accedere alle schermate caricate quando è ragionevolmente necessario per il funzionamento del servizio.  Potete eliminare le schermate caricate in qualsiasi momento.  
+* __Caricamento di schermate catturate__: ke schermate catturate che scegliete di caricare vengono inviate a Mozilla e memorizzate per il periodo limitato indicato, che potrete modificare. Possiamo accedere alle schermate caricate quando è ragionevolmente necessario per il funzionamento del servizio. Potete eliminare le schermate caricate in qualsiasi momento.
 
-* __Dati sull’interazione__: Riceviamo dati come visite al sito web Firefox Screenshots, la frequenza con cui si accede alle schermate caricate e con cui queste sono condivise da voi o da altri, le vostre interazioni con pulsanti, tile, e movimenti del mouse relativi alla cattura di schermate.
+* __Dati sull’interazione__: riceviamo dati come visite al sito web Firefox Screenshots, la frequenza con cui si accede alle schermate caricate e con cui queste sono condivise da voi o da altri, le vostre interazioni con pulsanti, pannelli, e movimenti del mouse relativi alla cattura di schermate.
 
-    Per visite al sito web Firefox Screenshots, il nostro avviso di [informativa sulla privacy  dei siti web](https://www.mozilla.org/privacy/websites/) descrive i tipi di dati che si possono ulteriormente raccogliere.
+  Per visite al sito web Firefox Screenshots, il nostro avviso di [informativa sulla privacy dei siti web](https://www.mozilla.org/privacy/websites/) descrive i tipi di dati che si possono ulteriormente raccogliere.
 
-* __Dati tecnici__: Riceviamo dati come le dimensioni medie, il numero di schermate caricate, il numero di versione del browser Firefox, il sistema opertivo del dispositivo e gli errori.  L’indirizzo  IP che accede al sito web Firefox Screenshots viene raccolto temporaneamente quale parte di un log di server standard. 
+* __Dati tecnici__: riceviamo dati come le dimensioni medie, il numero di schermate caricate, la versione del browser Firefox, il sistema opertivo del dispositivo e gli errori. L’indirizzo IP che accede al sito web Firefox Screenshots viene raccolto temporaneamente quale parte di un log di server standard.
 
-Leggere la  [full documentazione](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) o[altre informazioni](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
+Leggere la [full documentazione](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) o [ulteriori informazioni](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
 
-### Notifiche sul sito web {: #push-notifications }
+### Notifiche da siti web {: #push-notifications }
 
-* __Dati di connessione__: Se consenti a un sito web di inviarti notifiche, Firefox si connette con Mozilla e usa il vostro indirizzo IP per riferire il messaggio.  Mozilla non può accedere al contenuto dei messaggi.    
+* __Dati di connessione__: se consentite a un sito web di inviarvi notifiche, Firefox si connette con Mozilla e usa il vostro indirizzo IP per riferire il messaggio. Mozilla non può accedere al contenuto dei messaggi.
 
-* __Dati sull’interazione__: Riceviamo dati aggregati, quali il numero delle iscrizioni o degli annullamenti delle iscrizioni Firefox alle notifiche del sito web, il numero di messaggi inviati, di timestamp e di destinatari (che potrebbero includere fornitore di servizi di siti web specifici).  
+* __Dati sull’interazione__: riceviamo dati aggregati, quali il numero delle iscrizioni o degli annullamenti delle iscrizioni in Firefox alle notifiche dei siti web, il numero di messaggi inviati, di timestamp e di destinatari (che potrebbero includere fornitore di servizi di siti web specifici).
 
-Leggere   [l’intera documentazione](https://mozilla-push-service.readthedocs.io/en/latest/) o [altre informazioni](https://support.mozilla.org/kb/push-notifications-firefox), che includono il modo di revocare le notifiche del sito web.
+Leggere [l’intera documentazione](https://mozilla-push-service.readthedocs.io/en/latest/) o [ulteriori informazioni](https://support.mozilla.org/kb/push-notifications-firefox), che includono il modo di revocare le notifiche dei siti web.
 
-### Componenti aggiuntivi{: #addons }
+### Componenti aggiuntivi {: #addons }
 
 È possibile installare componenti aggiuntivi da addons.mozilla.org (“AMO”) oppure dal Gestore componenti aggiuntivi di Firefox, accessibile dal pulsante del menu Firefox nella barra strumenti.
- 
-* __Query di ricerca__: Le query di ricerca nel Gestore componenti aggiuntivi sono inviate a Mozilla per farsi inviare suggerimenti sui componenti aggiuntivi.  
 
-* __Dati sull’interazione__:  Riceviamo dati aggregati sulle visite al sito web AMO e sul Gestore componenti aggiuntivi in Firefox, nonché dati sull’interazione con il contenuto di queste pagine. Leggere sulle pratiche dei dati sui  [siti web di Mozilla](https://www.mozilla.org/privacy/websites/).
+* __Query di ricerca__: le query di ricerca nel Gestore componenti aggiuntivi sono inviate a Mozilla per farsi inviare suggerimenti sui componenti aggiuntivi.
 
-* __Dati tecnici per aggiornamenti__: Firefox si connette periodicamente a  Mozilla per installare aggiornamenti ai componenti aggiuntivi.  I componenti aggiuntivi, la versione di Firefox, la lingua e il sistema operativo dei dispositivi sono usati per installare gli aggiornamenti corretti.  
+* __Dati sull’interazione__: riceviamo dati aggregati sulle visite al sito web AMO e sul Gestore componenti aggiuntivi in Firefox, nonché dati sull’interazione con il contenuto di queste pagine. Consulta questa pagina per informazioni sulle pratiche dei dati sui [siti web di Mozilla](https://www.mozilla.org/privacy/websites/).
+
+* __Dati tecnici per aggiornamenti__: Firefox si connette periodicamente a Mozilla per installare aggiornamenti dei componenti aggiuntivi. I componenti aggiuntivi, la versione di Firefox, la lingua e il sistema operativo dei dispositivi sono usati per installare gli aggiornamenti corretti.
 
 ---
 
 ### Nota a piè di pagina
 
-Questo avviso sulla privacy è destinato alla versione della release generale più recente di Firefox distribuita da Mozilla.  Se Firefox è stato ottenuto altrove, o se la versione eseguita è meno recente, la copia di Firefox può contenere diverse funzioni di privacy.  
+Questo avviso sulla privacy è destinato alla _release_ generale più recente di Firefox distribuita da Mozilla. Se Firefox è stato ottenuto altrove, o se la versione eseguita è meno recente, la copia di Firefox potrebbe contenere diverse funzioni relative alla privacy.
 {: #pre-release }
 
-Le versioni pre-release di Firefox distribuite da Mozilla (distribuite mediante canali quali  Nightly, Beta, TestFlight e BuddyBuild) sono sotto sviluppo in corso e possono contenere funzioni diverse sulla privacy. 
-
+Le versioni _pre-release_ di Firefox distribuite da Mozilla (distribuite mediante canali quali Nightly, Beta, TestFlight e BuddyBuild) sono in fase di sviluppo e possono contenere funzioni diverse sulla privacy.

--- a/firefox_privacy_notice/it.md
+++ b/firefox_privacy_notice/it.md
@@ -126,7 +126,7 @@ Leggere la [documentazione completa](https://github.com/mozilla/fxa-auth-server/
 
 * __Dati tecnici__: riceviamo dati come le dimensioni medie, il numero di schermate caricate, la versione del browser Firefox, il sistema opertivo del dispositivo e gli errori. L’indirizzo IP che accede al sito web Firefox Screenshots viene raccolto temporaneamente quale parte di un log di server standard.
 
-Leggere la [full documentazione](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) o [ulteriori informazioni](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
+Leggere la [documentazione completa](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) o [ulteriori informazioni](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
 
 ### Notifiche da siti web {: #push-notifications }
 


### PR DESCRIPTION
This kind of content should not really go out to people without proper review. Besides a poor quality localization (fragments left in English, missing spaces), markdown is broken in several places, and placeholders are showing on a place displayed to all users
https://www.mozilla.org/it/privacy/firefox/