### PR TITLE
Title format is incorrect (Firefox should be bold)

### DIFF
--- a/firefox_privacy_notice/cs.md
+++ b/firefox_privacy_notice/cs.md
@@ -1,4 +1,4 @@
-﻿## <span class="privacy-header-firefox">Prohlášení o ochraně osobních údajů</span> <span class="privacy-header-policy">Firefox</span>
+﻿## <span class="privacy-header-policy">Prohlášení o ochraně osobních údajů</span> <span class="privacy-header-firefox">Firefox</span>
 
 *Účinné od 28. září 2017*
 {: datetime="2017-09-28" }


### PR DESCRIPTION
@Mikzz, @MekliCZ
Firefox should be bold, not the other way around.

See the current production page: https://www.mozilla.org/cs/privacy/firefox/.  This is the US page: https://www.mozilla.org/en-US/privacy/firefox/