### PR TITLE
Title formatting incorrect

### DIFF
--- a/firefox_privacy_notice/id.md
+++ b/firefox_privacy_notice/id.md
@@ -1,4 +1,4 @@
-﻿## <span class="privacy-header-firefox">Pemberitahuan</span> <span class="privacy-header-policy">Privasi Firefox</span>
+﻿## <span class="privacy-header-policy">Pemberitahuan Privasi</span> <span class="privacy-header-firefox">Firefox</span>
 
 *Berlaku 28 September 2017*
 {: datetime="2017-09-28" }


### PR DESCRIPTION
Firefox should be bold, not the other way around. 

On production: https://www.mozilla.org/id/privacy/firefox/ vs en-US: https://www.mozilla.org/en-US/privacy/firefox/