### PR TITLE
Fix title formatting

### DIFF
--- a/firefox_privacy_notice/es-ES.md
+++ b/firefox_privacy_notice/es-ES.md
@@ -1,4 +1,4 @@
-﻿## <span class="privacy-header-firefox"></span> <span class="privacy-header-policy">Aviso de privacidad de Firefox</span>
+﻿## <span class="privacy-header-policy">Aviso de privacidad de</span> <span class="privacy-header-firefox">Firefox</span>
 
 *Vigente a partir del 28 de septiembre de 2017*
 {: datetime="2017-09-28" }


### PR DESCRIPTION
Firefox should be bold.

On production: https://www.mozilla.org/es-ES/privacy/firefox/ vs. en-US https://www.mozilla.org/en-US/privacy/firefox/