### PR TITLE
Fix title formatting

### DIFF
--- a/firefox_privacy_notice/pt-BR.md
+++ b/firefox_privacy_notice/pt-BR.md
@@ -1,4 +1,4 @@
-﻿## <span class="privacy-header-firefox">Aviso de privacidade do</span> <span class="privacy-header-policy">Firefox</span>
+﻿## <span class="privacy-header-policy">Aviso de privacidade do</span> <span class="privacy-header-firefox">Firefox</span>
 
 *Vigência em 28 de setembro de 2017*
 {: datetime="2017-09-28" }


### PR DESCRIPTION
Firefox should be bold, not the other way round.

On production: https://www.mozilla.org/pt-BR/privacy/firefox/ vs. en-US: https://www.mozilla.org/en-US/privacy/firefox/

@cynthiapereira please confirm so I can merge.