### PR TITLE
Update firefox_privacy_notice/cs.md

### DIFF
--- a/firefox_privacy_notice/cs.md
+++ b/firefox_privacy_notice/cs.md
@@ -7,13 +7,13 @@
 
 Proto vytváříme Firefox a veškeré naše produkty tak, abyste měli větší kontrolu nad informacemi, které sdílíte online, a informacemi, které sdílíte s námi. Snažíme se shromažďovat pouze to, co potřebujeme ke zlepšení Firefoxu pro každého.
 
-V tomto Oznámení o ochraně osobních údajů vysvětlujeme, jaké údaje Firefox sdílí, a představíme vám nastavení, které jich umožní sdílet ještě méně. Rovněž dodržujeme postupy stanovené v [zásadách ochrany osobních údajů](https://www.mozilla.org/privacy/) společnosti Mozilla pro to, jak získáváme vaše informace shromážděné z Firefoxu, jak s nimi zacházíme a jak je sdílíme.
+V tomto Prohlášení o ochraně osobních údajů vysvětlujeme, jaké údaje Firefox sdílí, a představíme vám nastavení, která jich umožní sdílet ještě méně. Rovněž dodržujeme postupy stanovené v [Zásadách ochrany osobních údajů](https://www.mozilla.org/privacy/) společnosti Mozilla, jak získáváme vaše informace shromážděné z Firefoxu, jak s nimi zacházíme a jak je sdílíme.
 
 ## Dle výchozího nastavení Firefox sdílí údaje pro:
 
-### zvýšení výkonu a stability pro uživatele všude po světě {: #health-report }
+### Zvýšení výkonu a stability pro uživatele na celém světě {: #health-report }
 
-* __Údaje o interakci__: Firefox zasílá data o vaší interakci s Firefoxem nám (jako je počet otevřených karet, počet navštívených webových stránek, počet a typ nainstalovaných Doplňků Firefox a délka relace) a s funkcemi Firefox nabízené společností Mozilla nebo našimi partnery (jako je interakce s funkcemi vyhledávání Firefoxu a odkazy na vyhledávané partnery).  
+* __Údaje o interakci__: Firefox nám zasílá data o vaší interakci s Firefoxem (jako je počet otevřených panelů, počet navštívených webových stránek, počet a typ nainstalovaných doplňků ve Firefoxu a délka relace) a s funkcemi Firefoxu nabízenými společností Mozilla nebo našimi partnery (jako je interakce s funkcemi vyhledávání ve Firefoxu a s odkazy na vyhledávané partnery).
 
 * __Technické údaje__: Firefox nám zasílá údaje o vaší verzi a jazyce Firefoxu; operačním systému zařízení a konfiguraci hardwaru; paměti, základních informací o pádech a chybách; výsledku automatizovaných procesů, jako jsou aktualizace, bezpečné procházení a aktivace.  Když nám Firefox zasílá údaje, dočasně se v protokolu našeho serveru shromažďuje vaše adresa IP.  
 
@@ -22,17 +22,17 @@ Přečtěte si dokumentaci o telemetrii pro [stolní počítače](https://firefo
 
 ### Nastavení výchozího poskytovatele vyhledávání {: #defaultsearch }
 
-* __Údaje o místě__:  Při prvním použití Firefoxu využívá vaši adresu IP pro nastavení vašeho výchozího poskytovatele vyhledávání podle vaší země.  [Podrobnější informace](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
+* __Údaje o místě__:  Při prvním použití Firefoxu využívá vaši IP adresu pro nastavení vašeho výchozího poskytovatele vyhledávání podle vaší země. [Podrobnější informace](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
 
-### Návrh relevantního obsahu 
+### Navrhování relevantního obsahu
 
-Firefox zobrazuje obsah, jako jsou například „snippety“ (zprávy od společnosti Mozilla) a Nejlepší stránky (webové stránky navržené společností Mozilla pro první použití Firefoxu uživateli).
+Firefox zobrazuje obsah, jako jsou například „snippety“ (zprávy od společnosti Mozilla) a Top stránky (webové stránky navržené společností Mozilla pří prvním použití Firefoxu).
 
-* __Údaje o místě__: Firefox využívá vaši adresu IP pro návrh relevantního obsahu podle vaší země.
+* __Údaje o místě__: Firefox využívá vaši IP adresu pro návrh relevantního obsahu podle vaší země.
 
-* __Technické údaje a údaje o interakci__: Firefox nám zasílá údaje jako například o poloze, velikosti a umístění námi navrhovaného obsahu, jakož i základní údaje o vaší interakci s navrhovaným obsahem Firefoxu. To zahrnuje počet zobrazení navrhovaného obsahu nebo kliknutí na něj.
+* __Technické údaje a údaje o interakci__: Firefox nám zasílá údaje například o poloze, velikosti a umístění námi navrhovaného obsahu, jakož i základní údaje o vaší interakci s navrhovaným obsahem Firefoxu. To zahrnuje počet zobrazení navrhovaného obsahu nebo kliknutí na něj.
 
-* __Údaje o webové stránce pro snippety__: Pokud se rozhodnete kliknout na odkaz snippetu, mžeme získat údaje o odkazu, který jste použili. Tyto informace nesouvisí s žádnými jinými informacemi o vás. [Podrobnější informace](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
+* __Údaje o webové stránce pro snippety__: Pokud se rozhodnete kliknout na odkaz snippetu, můžeme získat údaje o odkazu, který jste použili. Tyto informace nejsou spojovány s žádnými jinými informacemi o vás. [Podrobnější informace](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
 {: #snippets }
 
 ### Zlepšení bezpečnosti pro všechny uživatele na celém světě {: #security }
@@ -40,40 +40,40 @@ Firefox zobrazuje obsah, jako jsou například „snippety“ (zprávy od spole�
 * __Technické údaje pro aktualizace__: Verze Firefoxu pro stolní počítače pravidelně kontrolují aktualizace prohlížeče připojením se k serverům společnosti Mozilla. Informace o vaší verzi Firefoxu, jazyce a operačním systému zařízení se použijí pro aplikaci správné aktualizace. Mobilní verze Firefoxu se mohou připojovat k jiné službě, pokud jste ji použili ke stažení a instalaci Firefoxu. [Podrobnější informace](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
 {: #auto-updates }
 
-* __Technické údaje pro seznam blokování doplňků__: Firefox pro stolní počítače a systém Android se pravidelně připojuje ke společnosti Mozilla, aby vás i ostatní chránil před škodlivými doplňky.  Informace o vaší verzi a jazyce Firefoxu, o operačním systému zařízení, stejně jako seznam nainstalovaných doplňků jsou nezbytné pro aplikaci a aktualizaci seznamu blokovaných doplňků. [Podrobnější informace](https://support.mozilla.org/kb/how-stop-firefox-making-automatic-connections). 
+* __Technické údaje pro seznam blokováných doplňků__: Firefox pro počítač a systém Android se pravidelně připojuje ke společnosti Mozilla, aby vás i ostatní chránil před škodlivými doplňky. Informace o vaší verzi a jazyce Firefoxu, o operačním systému zařízení, stejně jako seznam nainstalovaných doplňků jsou nezbytné pro aplikaci a aktualizaci seznamu blokovaných doplňků. [Podrobnější informace](https://support.mozilla.org/kb/how-stop-firefox-making-automatic-connections).
 
-* __Údaje o webové stránce a technické údaje pro službu SafeBrowsing společnosti Google__: Jako pomůcku pro ochranu před škodlivými stahovanými soubory Firefox zasílá základní informace o nerozpoznaných stahovaných souborech do služby SafeBrowsing společnosti Google, a to včetně názvu souboru a adresy URL, z níž byl stažen.  
+* __Údaje o webové stránce a technické údaje pro službu SafeBrowsing společnosti Google__: Jako pomůcku pro ochranu před stažením škodlivých souborů Firefox zasílá základní informace o nerozpoznaných stahovaných souborech do služby SafeBrowsing společnosti Google, a to včetně názvu souboru a adresy URL, z níž byl stažen.
 
     [Získejte podrobnější informace](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) nebo si přečtěte [Zásady ochrany osobních údajů společnosti Google](https://www.google.com/policies/privacy/). Zrušení této volby zabrání Firefoxu v tom, aby vás varoval před potenciálně nelegálními či škodlivými webovými stránkami či stahovanými soubory.
 
-* __Údaje o webové stránce a technické údaje pro certifikační autority__: Pokud navštívíte zabezpečenou webovou stránku (obvykle označenou adresu URL začínající na „HTTPS“), Firefox ověří [certifikát](https://support.mozilla.org/kb/secure-website-certificate)webové stránky. To může být spojeno s tím, že Firefox zašle určité informace o webové stránce Certifikační autoritě uvedené na příslušné webové stránce.  
+* __Údaje o webové stránce a technické údaje pro certifikační autority__: Pokud navštívíte zabezpečenou webovou stránku (obvykle označenou adresou URL začínající na „HTTPS“), Firefox ověří [certifikát](https://support.mozilla.org/kb/secure-website-certificate) webové stránky. To může být spojeno s tím, že Firefox zašle určité informace o webové stránce certifikační autoritě uvedené na příslušné webové stránce.
 
     Zrušením této volby riskujete zachycení vašich osobních informací. [Podrobnější informace](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab).
 
-### Zprávy o pádech {: #crash-reporter }
-Dle výchozího nastavení u verzí Firefoxu pro stolní počítače vás požádáme o sdílení podrobnějších informací o pádech společnosti Mozilla, nicméně vždy máte možnost to odmítnout.
+### Zasílání hlášení o pádech {: #crash-reporter }
+Dle výchozího nastavení u verzí Firefoxu pro počítač vás požádáme o sdílení podrobnějších informací o pádech společnosti Mozilla, nicméně vždy máte možnost to odmítnout.
 
-* __Citlivé údaje__:  Zprávy o pádech zahrnují „vyhozený soubor“ s obsahem pamětí Firefoxu v okamžiku pádu, který může obsahovat data, které vás identifikují nebo jsou pro vás jinak citlivé.
+* __Citlivé údaje__: Hlášení o pádech zahrnují „dump soubor“ s obsahem pamětí Firefoxu v okamžiku pádu, který může obsahovat data, které vás identifikují nebo jsou pro vás jinak citlivá.
 
-* __Údaje o webové stránce__:  Zprávy o pádech zahrnují aktivní adresu URL v okamžiku pádu.
+* __Údaje o webové stránce__: Hlášení o pádech zahrnují aktivní URL adresu v okamžiku pádu.
 
-* __Technické údaje__:  Zpráva o pádu zahrnuje data o tom, proč Firefox spadl, jakož i stav paměti zařízení a provádění během pádu.
+* __Technické údaje__:  Hlášení o pádu zahrnuje data o tom, proč Firefox spadl, jakož i stav paměti zařízení a provádění během pádu.
 
 Úplnou dokumentaci si přečtěte [zde](https://firefox-source-docs.mozilla.org/toolkit/crashreporter/crashreporter/index.html).
 
 ### Měření a podporu našeho marketingu
 
-* __Údaje o kampaních a doporučeních__: To společnosti Mozilla pomáhá pochopit efektivitu našich marketingových kampaní.
+* __Údaje o kampaních a doporučeních__: Tyto údaje společnosti Mozilla pomáhají pochopit efektivitu našich marketingových kampaní.
 {: #referraltracking }
 
-    _U stolních počítačů_: Firefox dle výchozího nastavení zasílá společnosti Mozilla údaje o HTTP, které mohou být součástí instalačního souboru Firefoxu.  To nám umožňuje stanovit doménu webové stránky nebo (případné) reklamní kampaně, která vás odkázala na naši stránku stahování. Přečtěte si[dokumentaci](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) nebo [zrušte volbu](https://support.mozilla.org/kb/desktop-privacy) before installation.
+    _U počítačů_: Firefox dle výchozího nastavení zasílá společnosti Mozilla údaje o HTTP, které mohou být součástí instalačního souboru Firefoxu. To nám umožňuje stanovit doménu webové stránky nebo (případné) reklamní kampaně, která vás odkázala na naši stránku stahování. Přečtěte si [dokumentaci](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) nebo před instalací [zrušte volbu](https://support.mozilla.org/kb/desktop-privacy).
 
-    _Na iOS a Android_: Firefox dle výchozího nastavení zasílá mobilní kampaně společnosti Adjust, našemu dodavateli analýz, který má své vlastní [zásady ochrany osobních údajů](https://www.adjust.com/privacy_policy/).  Údaje o mobilních kampaních zahrnují ID reklamy Google, adresu IP, časovou značku, zemi, jazyk/místní variantu, operační systém a verzi aplikace. Přečtěte si [dokumentaci](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
+    _Na systémech iOS a Android_: Firefox dle výchozího nastavení zasílá mobilní kampaně společnosti Adjust, našemu dodavateli analýz, který má své vlastní [zásady ochrany osobních údajů](https://www.adjust.com/privacy_policy/). Údaje o mobilních kampaních zahrnují ID reklamy Google, IP adresu, časovou značku, zemi, jazyk/nastavení místního prostředí, operační systém a verzi aplikace. Přečtěte si [dokumentaci](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
 {: #thirdparty }
 
 * __Technické údaje a údaje o interakci__: 
 
-    _Na iOS a Android_: Firefox dle výchozího nastavení zasílá údaje o tom, jaké funkce ve Firefoxu využíváte, společnosti Leanplum, našemu dodavateli mobilního marketingu, který má své vlastní [zásady ochrany osobních údajů](https://www.leanplum.com/privacy/).  Tyto údaje nám pomáhají testovat různé funkce a zkušenosti, stejně jako zasílat přizpůsobené zprávy a doporučení ke zlepšení vašich zkušeností s aplikací Firefox.
+    _Na systémech iOS a Android_: Firefox dle výchozího nastavení zasílá údaje o tom, jaké funkce ve Firefoxu využíváte, společnosti Leanplum, našemu dodavateli mobilního marketingu, který má své vlastní [zásady ochrany osobních údajů](https://www.leanplum.com/privacy/). Tyto údaje nám pomáhají testovat různé funkce a chování, stejně jako zasílat přizpůsobené zprávy a doporučení ke zlepšení vašeho prožitku s aplikací Firefox.
 
     Přečtěte si dokumentaci pro [iOS](https://github.com/mozilla-mobile/firefox-ios/blob/master/MMA.md) nebo [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/mma.html), či získejte podrobnější informace o tom, [jak tuto funkci deaktivovat](https://support.mozilla.org/kb/send-anonymous-usage-data-firefox-mobile-devices).
 

--- a/firefox_privacy_notice/cs.md
+++ b/firefox_privacy_notice/cs.md
@@ -71,7 +71,7 @@ Dle výchozího nastavení u verzí Firefoxu pro počítač vás požádáme o s
     _Na systémech iOS a Android_: Firefox dle výchozího nastavení zasílá mobilní kampaně společnosti Adjust, našemu dodavateli analýz, který má své vlastní [zásady ochrany osobních údajů](https://www.adjust.com/privacy_policy/). Údaje o mobilních kampaních zahrnují ID reklamy Google, IP adresu, časovou značku, zemi, jazyk/nastavení místního prostředí, operační systém a verzi aplikace. Přečtěte si [dokumentaci](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
 {: #thirdparty }
 
-* __Technické údaje a údaje o interakci__: 
+* __Technické údaje a údaje o interakci__:
 
     _Na systémech iOS a Android_: Firefox dle výchozího nastavení zasílá údaje o tom, jaké funkce ve Firefoxu využíváte, společnosti Leanplum, našemu dodavateli mobilního marketingu, který má své vlastní [zásady ochrany osobních údajů](https://www.leanplum.com/privacy/). Tyto údaje nám pomáhají testovat různé funkce a chování, stejně jako zasílat přizpůsobené zprávy a doporučení ke zlepšení vašeho prožitku s aplikací Firefox.
 
@@ -79,79 +79,78 @@ Dle výchozího nastavení u verzí Firefoxu pro počítač vás požádáme o s
 
 ---
 
-## Pokud tyto funkce používáte, Firefox bude sdílet údaje pro poskytování funkce:  {: #optional-features }
+## Pokud tyto funkce používáte, Firefox bude sdílet údaje pro poskytování funkcí: {: #optional-features }
 
 ### Vyhledávání
 
-Vyhledávání můžete provádět přímo na několika místech ve Firefoxu, včetně lišty Awesome, lišty vyhledávání nebo na Nové kartě.  _Společnost Mozilla vaše dotazy pro vyhledávání nezískává._ Údaje o dotazech jsou zasílány poskytovateli vyhledávání, který má své vlastní zásady ochrany osobních údajů.  
+Přímé vyhledávání můžete ve Firefoxu provádět na několika místech, včetně chytrého adresního řádku, lišty vyhledávání nebo na stránce nového panelu. _Společnost Mozilla vaše dotazy pro vyhledávání nezískává._ Údaje o dotazech jsou zasílány poskytovateli vyhledávání, který má své vlastní zásady ochrany osobních údajů.
 
-* __Návrhy pro vyhledávání__: Firefox dle výchozího nastavení odesílá dotazy pro vyhledávání vašemu poskytovateli vyhledávání jako pomůcku pro zjištění nejčastějších frází, které jiní lidé vyhledávali, jakož i pro zlepšení vaší zkušenosti s vyhledáváním. Tyto údaje nebudou zasílány, pokud váš poskytovatel vyhledávání návrhy nepodporuje.
-{: #searchsuggestions } 
+* __Návrhy pro vyhledávání__: Firefox dle výchozího nastavení odesílá dotazy pro vyhledávání vašemu poskytovateli vyhledávání jako pomůcku pro zjištění nejčastějších frází, které vyhledávali jiní lidé, jakož i pro zlepšení vaší zkušenosti s vyhledáváním. Tyto údaje nebudou zasílány, pokud váš poskytovatel návrhy pro vyhledávání nepodporuje.
+{: #searchsuggestions }
 
     [Získejte podrobnější informace](https://support.mozilla.org/kb/use-popular-search-suggestions-firefox-search-bar), včetně toho, jak tuto funkci deaktivovat.
 
-### Účty Firefox
+### Účet Firefoxu
 
-* __Údaje o účtu Firefox __: Mozilla získává vaši e.mailovou adresu a šifrované heslo v okamžiku, kdy vytvoříte svůj účet Firefox.  Můžete se rozhodnout zahrnout i zobrazované jméno nebo profilový obrázek.  Vaše e-mailová adresa se zasílá našemu poskytovateli e-mailu, společnosti SalesForce Marketing Cloud, která má své vlastní [zásady ochrany osobních údajů](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Pokud používáte náš Účet Firefox pro přihlašování k webovým stránkám nebo službám (jako například AMO nebo Pocket), získáme časovou značku vašeho přihlášení od těchto služeb. 
+* __Údaje o účtu Firefoxu__: Mozilla obdrží vaši e-mailovou adresu a hash vašeho hesla v okamžiku, kdy si vytvoříte svůj účet Firefoxu. Můžete se rozhodnout zahrnout i zobrazované jméno nebo profilový obrázek. Vaše e-mailová adresa se zasílá našemu poskytovateli e-mailu, společnosti SalesForce Marketing Cloud, která má své vlastní [zásady ochrany osobních údajů](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Pokud používáte náš účet Firefoxu pro přihlašování k webovým stránkám nebo službám (jako například AMO nebo Pocket), získáme časovou značku vašeho přihlášení k těmto službám.
 
-* __Údaje o místě__: Pro bezpečnostní účely ukládáme adresy IP, které používáte pro přístup k vašemu účtu Firefox pro přibližné stanovení města a země.  Tato data používáme k zasílání e-mailových varování, pokud zjistíme podezřelou činnost, jako například přihlášení k účtu z jiných míst.
+* __Údaje o místě__: Pro bezpečnostní účely ukládáme IP adresy, z nichž přistupujete k vašemu účtu Firefoxu pro přibližné stanovení města a země. Tato data používáme k zasílání e-mailových varování, pokud zjistíme podezřelou činnost, jako například přihlášení k účtu z jiných míst.
 
-* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek účtů Firefox a interakci s nimi, jakož i o předvolbách nabídek a interakcích s registrací, e-mailem a SMS zprávami. [Získejte podrobnější informace](https://www.mozilla.org/privacy/websites/) o datových postupech společnosti Mozilla pro webové stránky a e-mail.  
+* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek účtu Firefoxu a interakci s nimi, jakož i o předvolbách a interakcích při registraci registraci a nabídkami nastavní e-mailu a SMS zpráv. [Získejte podrobnější informace](https://www.mozilla.org/privacy/websites/) o datových postupech společnosti Mozilla pro webové stránky a e-mail.
 
-* __Technické údaje__: Pro zobrazení, která zařízení jsou synchronizována s vašim účtem Firefox a pro zajištění fungování, ukládáme informace o operačním systému vašeho zařízení, prohlížeči a verzi, časové značce, místě a stejné informace o zařízeních připojených k vašemu účtu.  
+* __Technické údaje__: Abychom vám mohli zobrazit zařízení, která jsou s vašim účtem Firefoxu synchronizována, ukládáme informace o operačním systému vašeho zařízení, prohlížeči a verzi, časové značce, místě a stejné informace o zařízeních připojených k vašemu účtu.
 
-Přečtěte si [úplnou dokumentaci](https://github.com/mozilla/fxa-auth-server/blob/master/docs/metrics-events.md) nebo [získejte podrobnější informace](https://support.mozilla.org/kb/access-mozilla-services-firefox-accounts), včetně toho, jak [váš účet vymazat](https://support.mozilla.org/kb/how-do-i-delete-my-firefox-account).
+Přečtěte si [úplnou dokumentaci](https://github.com/mozilla/fxa-auth-server/blob/master/docs/metrics-events.md) nebo [získejte podrobnější informace](https://support.mozilla.org/kb/access-mozilla-services-firefox-accounts) včetně toho, jak můžete [svůj účet zrušit](https://support.mozilla.org/kb/how-do-i-delete-my-firefox-account).
 
-### Synchronizaci {: #sync }
+### Synchronizace {: #sync }
 
-* __Synchronizované údaje__: Pokud aktualizujete Synchronizaci, společnost Mozilla získává informace, které synchronizujete napříč zařízeními v šifrované formě. To může zahrnovat informace o kartách Firefoxu, doplňcích, heslech, automaticky vyplňované platební informace, záložky, historii a předvolby.  Vymazáním vašeho účtu Firefox vymažete související obsah synchronizace Firefox. Můžete si rovněž přečíst [dokumentaci](https://moz-services-docs.readthedocs.io/en/latest/sync/).
-  
-* __Technické údaje a údaje o interakci__: Pokud aktivujete synchronizaci, Firefox bude pravidelně odesílat základní informace s pomocí Telemetrie o posledních pokusech o synchronizaci vašich dat, jako například kdy k nim došlo, zda byly úspěšné či nikoliv, a o tom, o synchronizaci jakého typu služby jste se pokoušeli. Můžete si rovněž přečíst [dokumentaci](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html).
+* __Synchronizované údaje__: Pokud Sync aktivujete, společnost Mozilla obdrží v šifrovaném formátu data, které synchronizujete mezi zařízeními. To může zahrnovat informace o panelech Firefoxu, doplňcích, heslech, automaticky vyplňovaných platebních informacích, záložkách, historii a předvolbách. Smazání vašeho účtu Firefoxu vymažete související obsah služby Firefox Sync. Můžete si rovněž přečíst [dokumentaci](https://moz-services-docs.readthedocs.io/en/latest/sync/).
+
+* __Technické údaje a údaje o interakci__: Pokud Sync aktivujete, Firefox bude pravidelně v rámci telemetrie odesílat základní informace o posledních pokusech o synchronizaci vašich dat, jako například kdy k nim došlo, zda byly úspěšné či nikoliv, a o typu zařízení. Můžete si rovněž přečíst [dokumentaci](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html).
 
 [Získejte podrobnější informace](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), včetně toho, jak synchronizaci aktivovat či deaktivovat.
 
-### Místo {: #location-services }
+### Pro zjišťování polohy {: #location-services }
 
-* __Údaje o místě pro službu geolokace společnosti Google__: Firefox se vždy zeptá, než určí a sdílí vaše místo s požadovanou webovou stránkou (například, pokud webová stránka s mapou potřebuje znát vaše místo pro poskytnutí pokynů).  ke stanovení místa může Firefox používat funkci geolokace vašeho operačního systému, sítí WiFi, vysílače mobilních telefonů nebo adresy IP a tyto údaje může zasílat službě geolokace společnosti Google, která má své vlastní [zásady ochrany osobních údajů](https://www.google.com/privacy/lsf.html).
+* __Údaje o místě pro službu geolokace společnosti Google__: Před určením a sdílením vaší pozice s webovou stránkou se vás Firefox vždy dotáže (např. pokud webová stránka s mapou potřebuje znát vaše místo pro vaši navigaci). Ke stanovení místa může Firefox používat funkci geolokace vašeho operačního systému, Wi-Fi sítě, vysílače mobilní sítě nebo IP adresy, a tyto údaje může zasílat službě geolokace společnosti Google, která má své vlastní [zásady ochrany osobních údajů](https://www.google.com/privacy/lsf.html).
 
 [Podrobnější informace](https://www.mozilla.org/firefox/geolocation/).
 
-### Snímky obrazovky aplikace Firefox {: #screenshots }
+### Firefox Screenshots {: #screenshots }
 
-* __Nahrávání snímků obrazovky__: Snímky obrazovky, které se rozhodnete nahrát, se odesílají společnosti Mozilla a jsou ukládány po uvedenou omezenou dobu, kterou můžete změnit.  Můžete využívat přístup k vašim nahraným snímkům obrazovky, pokud je to rozumně nezbytné pro poskytování služby.  Nahrané snímky obrazovky můžete kdykoliv odstranit.  
+* __Nahrávání snímků__: Snímky, které se rozhodnete nahrát, se odesílají společnosti Mozilla a jsou ukládány po uvedenou omezenou dobu, kterou můžete změnit. K vašim nahraným snímkům můžeme přistupovat, pokud je to rozumně nezbytné pro poskytování služby. Nahrané snímky můžete kdykoliv odstranit.
 
-* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek Firefox Screenshots, jak často přistupujete ke snímkům obrazovky, které nahráváte a jak je sdílíte s ostatními, stejně jako vaše používání tlačítek, dlaždic a pohyby myší související s pořízením snímku obrazovky.
+* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek Firefox Screenshots, jak často přistupujete ke svým snímkům, které nahrajete, a jak je sdílíte s ostatními, stejně jako vaše interakce při používání tlačítek, dlaždic a pohyby myší související s pořízováním snímků.
 
-    Pro návštěvy webových stránek Firefox Screenshots naše [oznámení o zásadách ochrany osobních údajů na webových stránkách](https://www.mozilla.org/privacy/websites/) popisuje, které typy další dat shromažďujeme.
+    Pro návštěvy webových stránek Firefox Screenshots, naše [oznámení o zásadách ochrany osobních údajů na webových stránkách](https://www.mozilla.org/privacy/websites/) popisuje, které typy další dat shromažďujeme.
 
-* __Technické údaje__: Získáváme taková data jako je průměrná velikost a počet vámi nahraných snímků obrazovky, vaše verze prohlížeče Firefox, operační systém zařízení a chyby.  Adresa IP využitá pro přístup na webové stránky Firefox Screenshots je dočasně shromažďuje v rámci standardního protokolu serveru. 
+* __Technické údaje__: Získáváme taková údaje, jako je průměrná velikost a počet vámi nahraných snímků, vaše verze prohlížeče Firefox, operační systém zařízení a chyby. IP adresa využitá pro přístup na webové stránky Firefox Screenshots je dočasně uložena v rámci standardního protokolu serveru.
 
 Přečtěte si [úplnou dokumentaci](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) nebo [získejte podrobnější informace](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
 
-### Oznámení na webových stránkách {: #push-notifications }
+### Oznámení z webových stránek {: #push-notifications }
 
-* __Údaje o připojení__: Pokud povolíte webovým stránkám zasílat oznámení, Firefox se spojí se společností Mozilla a využije vaši adresu IP pro doručení zprávy.  Mozilla nemá přístup k obsahu zprávy.    
+* __Údaje o připojení__: Pokud povolíte webovým stránkám zasílat vám oznámení, Firefox se spojí se společností Mozilla a využije vaši IP adresu pro doručení zprávy. Mozilla nemá přístup k obsahu zprávy.
 
-* __Údaje o interakci__: Získáváme souhrnná data, jako je počet registrací a zrušení registrací odběrů Firefox pro oznámení webových stránek, počet zaslaných zpráv, časové značky a odesilatelé (což může zahrnovat poskytovatele konkrétních webových stránek).  
+* __Údaje o interakci__: Získáváme souhrnná data, jako je počet registrací a zrušení registrací odběrů oznámení webových stránek, počet zaslaných zpráv, časové značky a odesilatele (což může zahrnovat poskytovatele konkrétních webových stránek).
 
 Přečtěte si [úplnou dokumentaci](https://mozilla-push-service.readthedocs.io/en/latest/) nebo [získejte podrobnější informace](https://support.mozilla.org/kb/push-notifications-firefox), včetně toho, jak oznámení webových stránek zrušit.
 
 ### Doplňky {: #addons }
 
-Doplňky můžete nainstalovat ze stránky addons.mozilla.org („AMO“) nebo ze Správce doplňků Firefoxu, které je dostupný pomocí tlačítka nabídky Firefoxu v liště nástrojů.
- 
-* __Dotazy vyhledávání__: Dotazy vyhledávání ve Správci doplňků jsou zasílány společnosti Mozilla, aby vám mohl zasílat doporučení na Doplňky.  
+Doplňky můžete nainstalovat ze stránky addons.mozilla.org („AMO“) nebo ze Správce doplňků Firefoxu, který je dostupný pomocí tlačítka nabídky Firefoxu v liště nástrojů.
 
-* __Údaje o interakci__:  Získáváme souhrnné údaje o návštěvách webové stránky AMO a Správce doplňků Firefoxu, stejně jako o interakcích s obsahem těchto stránek. Přečtěte si o datových postupech na [webových stránkách Mozilla](https://www.mozilla.org/privacy/websites/).
+* __Dotazy vyhledávání__: Dotazy vyhledávání ve Správci doplňků jsou zasílány společnosti Mozilla, aby vám mohla zasílat doporučení na další doplňky.
 
-* __Technické údaje pro aktualizace__: Firefox se pravidelně spojuje se společností Mozilla za účelem instalace aktualizací Doplňků.  Informace o nainstalovaných Doplňcích, vaší verzi a jazyce Firefoxu a operačním systému zařízení se použijí pro aplikaci správné aktualizace.  
+* __Údaje o interakci__:  Získáváme souhrnné údaje o návštěvách webové stránky AMO a Správce doplňků Firefoxu, stejně jako o interakcích s obsahem těchto stránek. Přečtěte si o datových postupech na [webových stránkách Mozilly](https://www.mozilla.org/privacy/websites/).
+
+* __Technické údaje pro aktualizace__: Firefox se pravidelně spojuje se společností Mozilla za účelem instalace aktualizací doplňků. Informace o nainstalovaných doplňcích, verze a jazyk Firefoxu a operačního systému zařízení se použijí pro aplikaci správné aktualizace.
 
 ---
 
 ### Poznámka pod čarou
 
-Toto oznámen o ochraně osobních údajů platí pro nejnovější obecně vydanou verzi Firefoxu distribuovaného společností Mozilla.  Pokud získáte Firefox odjinud nebo pokud používáte starší verzi, vaše kopie Firefoxu může obsahovat odlišné charakteristiky ochrany osobních údajů.  
+Toto Prohlášení o ochraně osobních údajů platí pro nejnovější obecně vydanou verzi Firefoxu distribuovaného společností Mozilla. Pokud získáte Firefox odjinud nebo pokud používáte starší verzi, vaše kopie Firefoxu může obsahovat odlišné charakteristiky ochrany osobních údajů.
 {: #pre-release }
 
-Předběžná vydání verzí Firefoxu společnosti Mozilla (které jsou distribuovány kanály jako např. Nightly, Beta, TestFlight a BuddyBuild) jsou ve fázi aktivního vývoje a mohou obsahovat odlišné charakteristiky ochrany osobních údajů. 
-
+Předběžná vydání verzí Firefoxu společnosti Mozilla (které jsou distribuovány kanály jako např. Nightly, Beta, TestFlight a BuddyBuild) jsou ve fázi aktivního vývoje a mohou obsahovat odlišné charakteristiky ochrany osobních údajů.

--- a/firefox_privacy_notice/cs.md
+++ b/firefox_privacy_notice/cs.md
@@ -7,7 +7,7 @@
 
 Proto vytváříme Firefox a veškeré naše produkty tak, abyste měli větší kontrolu nad informacemi, které sdílíte online, a informacemi, které sdílíte s námi. Snažíme se shromažďovat pouze to, co potřebujeme ke zlepšení Firefoxu pro každého.
 
-V tomto Prohlášení o ochraně osobních údajů vysvětlujeme, jaké údaje Firefox sdílí, a představíme vám nastavení, která jich umožní sdílet ještě méně. Rovněž dodržujeme postupy stanovené v [Zásadách ochrany osobních údajů](https://www.mozilla.org/privacy/) společnosti Mozilla, jak získáváme vaše informace shromážděné z Firefoxu, jak s nimi zacházíme a jak je sdílíme.
+V tomto Prohlášení o ochraně osobních údajů vysvětlujeme, jaké údaje Firefox sdílí, a představíme vám nastavení, která jich umožní sdílet ještě méně. Rovněž dodržujeme postupy stanovené v [Zásadách ochrany osobních údajů](https://www.mozilla.org/privacy/) společnosti Mozilla ohledně získávání vašich informací shromážděných z Firefoxu, zacházení s nimi a jejich sdílení.
 
 ## Dle výchozího nastavení Firefox sdílí údaje pro:
 
@@ -28,7 +28,7 @@ Přečtěte si dokumentaci o telemetrii pro [stolní počítače](https://firefo
 
 Firefox zobrazuje obsah, jako jsou například „snippety“ (zprávy od společnosti Mozilla) a Top stránky (webové stránky navržené společností Mozilla pří prvním použití Firefoxu).
 
-* __Údaje o místě__: Firefox využívá vaši IP adresu pro návrh relevantního obsahu podle vaší země.
+* __Údaje o místě__: Firefox využívá vaši IP adresu pro navrhování relevantního obsahu podle vaší země.
 
 * __Technické údaje a údaje o interakci__: Firefox nám zasílá údaje například o poloze, velikosti a umístění námi navrhovaného obsahu, jakož i základní údaje o vaší interakci s navrhovaným obsahem Firefoxu. To zahrnuje počet zobrazení navrhovaného obsahu nebo kliknutí na něj.
 
@@ -96,7 +96,7 @@ Přímé vyhledávání můžete ve Firefoxu provádět na několika místech, v
 
 * __Údaje o místě__: Pro bezpečnostní účely ukládáme IP adresy, z nichž přistupujete k vašemu účtu Firefoxu pro přibližné stanovení města a země. Tato data používáme k zasílání e-mailových varování, pokud zjistíme podezřelou činnost, jako například přihlášení k účtu z jiných míst.
 
-* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek účtu Firefoxu a interakci s nimi, jakož i o předvolbách a interakcích při registraci registraci a nabídkami nastavní e-mailu a SMS zpráv. [Získejte podrobnější informace](https://www.mozilla.org/privacy/websites/) o datových postupech společnosti Mozilla pro webové stránky a e-mail.
+* __Údaje o interakci__: Získáváme údaje, jako jsou návštěvy webových stránek účtu Firefoxu a interakci s nimi, jakož i o předvolbách a interakcích při registraci registraci a nabídkami nastavení e-mailu a SMS zpráv. [Získejte podrobnější informace](https://www.mozilla.org/privacy/websites/) o datových postupech společnosti Mozilla pro webové stránky a e-mail.
 
 * __Technické údaje__: Abychom vám mohli zobrazit zařízení, která jsou s vašim účtem Firefoxu synchronizována, ukládáme informace o operačním systému vašeho zařízení, prohlížeči a verzi, časové značce, místě a stejné informace o zařízeních připojených k vašemu účtu.
 
@@ -132,7 +132,7 @@ Přečtěte si [úplnou dokumentaci](https://github.com/mozilla-services/screens
 
 * __Údaje o připojení__: Pokud povolíte webovým stránkám zasílat vám oznámení, Firefox se spojí se společností Mozilla a využije vaši IP adresu pro doručení zprávy. Mozilla nemá přístup k obsahu zprávy.
 
-* __Údaje o interakci__: Získáváme souhrnná data, jako je počet registrací a zrušení registrací odběrů oznámení webových stránek, počet zaslaných zpráv, časové značky a odesilatele (což může zahrnovat poskytovatele konkrétních webových stránek).
+* __Údaje o interakci__: Získáváme souhrnná data, jako je počet registrací a zrušení registrací odběrů oznámení webových stránek, počet zaslaných zpráv, časové značky a odesílatele (což může zahrnovat poskytovatele konkrétních webových stránek).
 
 Přečtěte si [úplnou dokumentaci](https://mozilla-push-service.readthedocs.io/en/latest/) nebo [získejte podrobnější informace](https://support.mozilla.org/kb/push-notifications-firefox), včetně toho, jak oznámení webových stránek zrušit.
 


### PR DESCRIPTION
In "Firefox by default shares data to":
- Oznámení -> Prohlášení (be consistent about this document name)
- které -> která (plural)
- pro to (?)
- všude po světě -> na celém světě (use this consistently in the document)
- vaší interakci s Firefoxem nám (English translation word by word)
- karet -> panelů (terminology)
- Doplňků Firefox (English translation word by word)
- s funkcemi Firefox nabízené -> s funkcemi Firefoxu nabízenými (grammar)
- s funkcemi vyhledávání Firefoxu a odkazy -> s funkcemi vyhledávání ve Firefoxu a s odkazy (to speak clearly, we often repeat prepositions, even if they are the same, multiple times)
- adresa IP, adresa URL -> IP adresa, URL adresa (terminology)
- Návrh relevantního obsahu -> Navrhování relevantního obsahu (stay consistent with the reference to the higher level headline)
- Nejlepší stránky -> Top stránky (consistency with product)
- navržené společností Mozilla pro první použití Firefoxu uživateli (this would mean the very first use of Firefox by the very first user ever)
- jako například o poloze -> například o poloze ("jako" cannot be used with a preposition here)
- mžeme (typo)
- nesouvisí (would mean "not related")
- seznam blokování doplňků -> seznam blokovaných doplňků (better wording)
- stolní počítače -> počítač (consistency with product and mozilla.org website)
- škodlivými stahovanými soubory -> stažením škodlivých souborů (better wording)
- Zprávy o pádech -> Zasílání hlášení o pádech (stay consistent with the reference to the higher level headline)
- Zprávy o pádech -> Hlášení o pádech (consistency with product)
- vyhozený soubor -> dump soubor (there is not Czech translation for dump in this context)
- citlivé -> citlivá (declension)
- To společnosti Mozilla pomáhá -> Tyto údaje společnosti Mozilla pomáhají (better wording)
- vašich zkušeností -> vašeho prožitku (here experience is a user experience, which has different translations in Czech)