### PR TITLE
Update websites_privacy_notice/cs.md

### DIFF
--- a/websites_privacy_notice/cs.md
+++ b/websites_privacy_notice/cs.md
@@ -3,65 +3,65 @@
 6. září 2017
 {: datetime="2017-09-06" }
 
-Na ochraně vašeho soukromí nám záleží. Když o vás společnost Mozilla (to jsme my) shromažďuje informace, naše [Zásady ochrany osobních údajů společnosti Mozilla](https://www.mozilla.org/privacy/) popisují, jak s těmito informacemi budeme nakládat.
+Na ochraně vašeho soukromí nám záleží. Když o vás společnost Mozilla (to jsme my) shromažďuje informace, naše [Zásady ochrany soukromí](https://www.mozilla.org/privacy/) popisují, jak s těmito informacemi budeme nakládat.
 
 Toto oznámení o ochraně osobních údajů se vztahuje na webové stránky a mobilní aplikace provozované společností Mozilla, k nimž patří kromě jiných domény mozillians.org, mozilla.org, firefox.com a webmaker.org. Patří sem například  bugzilla.mozilla.org, reps.mozilla.org, careers.mozilla.org, developers.mozilla.org, support.mozilla.org, addons.mozilla.org a wiki.mozilla.org.
 
 ## Co byste měli vědět
 
-Může se stát, že během vaší interakce s námi na platformách sociálních médií od vás získáme osobní údaje, ať již žádáte o práci, o praxi nebo o stáž, hlásíte-li se dobrovolně jako člen komunity Mozilla nebo zasíláte-li nám uživatelskou zpětnou vazbu či požadavky. 
+Může se stát, že během vaší interakce s námi na platformách sociálních médií od vás získáme osobní údaje, ať již žádáte o práci, o praxi nebo o stáž, hlásíte-li se dobrovolně jako člen komunity Mozilla nebo zasíláte-li nám uživatelskou zpětnou vazbu či požadavky.
 {: #personal-info }
 
-* **Sociální média**: Přihlásíte-li se k účtům našich sociálních médií jako např. Twitter a Facebook, můžeme získat vaše osobní údaje. Používáte-li tyto sítě, platí jejich zásady ochrany osobních údajů a doporučujeme vám se s nimi seznámit.  
+* **Sociální média**: Přihlásíte-li se k účtům našich sociálních médií jako např. Twitter a Facebook, můžeme získat vaše osobní údaje. Používáte-li tyto sítě, platí jejich zásady ochrany osobních údajů a doporučujeme vám se s nimi seznámit.
 
-* **Žadatelé o práci, o praxi nebo o stáž**: Žadatelé o práci, o praxi nebo o stáž u společnosti Mozilla nám musí poskytnout jméno, adresu, telefonní číslo, e-mailovou adresu a životopis. Tyto informace používáme při zpracovávání a posuzování žádostí a pro komunikaci se žadateli ohledně příležitostí. Využíváme služeb externího dodavatele, který nám s žádostmi o zaměstnání pomáhá. Více informací o způsobech nakládání s osobními údaji u externích dodavatelů je uvedeno v našich [Zásadách ochrany soukromí společnosti Mozilla](https://www.mozilla.org/privacy/).
+* **Žadatelé o práci, o praxi nebo o stáž**: Žadatelé o práci, o praxi nebo o stáž u společnosti Mozilla nám musí poskytnout jméno, adresu, telefonní číslo, e-mailovou adresu a životopis. Tyto informace používáme při zpracovávání a posuzování žádostí a pro komunikaci se žadateli ohledně příležitostí. Využíváme služeb externího dodavatele, který nám s žádostmi o zaměstnání pomáhá. Více informací o způsobech nakládání s osobními údaji u externích dodavatelů je uvedeno v našich [Zásadách ochrany soukromí](https://www.mozilla.org/privacy/).
 
-* **Spolupracovníci**: Budete-li spolupracovat se společností Mozilla jako dobrovolný přispěvatel v rámci komunity, může být případně zapotřebí, aby s vámi společnost Mozilla a jiné subjekty komunikovaly přes e-mailovou adresu, kterou v souvislosti se svým příspěvkem poskytnete, a také za účelem uznání vašeho úsilí. Podílíte-li se na aplikacích Bugzilla, Mozilla Reps nebo kódové bázi, budou vaše emailová adresa a případně i vaše jméno veřejně k dispozici všem uživatelům internetu. Vytvoříte-li si profil na Mozillians.org, bude tento profil přístupný pro zaměstnance a spolupracovníky společnosti Mozilla. Údaje na vašem profilu můžete upravovat pomocí [Nastavení profilu](https://mozillians.org/user/edit). Někdy využíváme údaje o spolupracovnících ze zdrojů (např. Bugzilla) na panelech pro vizuální sdílení souhrnných dat o Mozilla komunitě. Příkladem je [https://wiki.mozilla.org/Contribute/Dashboards](https://wiki.mozilla.org/Contribute/Dashboards). Je-li to možné, snažíme se veřejně zobrazované kontaktní údaje omezit na minimum.
+* **Přispěvatelé**: Budete-li spolupracovat se společností Mozilla jako dobrovolný přispěvatel v rámci komunity, může být případně zapotřebí, aby s vámi společnost Mozilla a jiné subjekty komunikovaly přes e-mailovou adresu, kterou v souvislosti se svým příspěvkem poskytnete, a také za účelem uznání vašeho úsilí. Podílíte-li se na aplikacích Bugzilla, Mozilla Reps nebo na zdrojovém kódu, budou vaše e-mailová adresa a případně i vaše jméno veřejně k dispozici všem uživatelům internetu. Vytvoříte-li si profil na Mozillians.org, bude tento profil přístupný pro zaměstnance a spolupracovníky společnosti Mozilla. Údaje na vašem profilu můžete upravovat pomocí [Nastavení profilu](https://mozillians.org/user/edit). Někdy využíváme údaje o spolupracovnících ze zdrojů (např. Bugzilla) na panelech pro vizuální sdílení souhrnných dat o komunitě Mozilla. Příkladem je [https://wiki.mozilla.org/Contribute/Dashboards](https://wiki.mozilla.org/Contribute/Dashboards). Je-li to možné, snažíme se veřejně zobrazované kontaktní údaje omezit na minimum.
 
-* **Účty**: některé webové stránky jako například Marketplace, AMO, MDN a Webmaker vyžadují založení účtu, abyste mohli zasílat obsah vývojáře, odesílat uživatelské recenze či komentáře či instalovat určité typy aplikací.  V souvislosti se svým účtem vám mohou být pravidelně zasílány e-maily.
+* **Účty**: Některé webové stránky jako například Marketplace, AMO, MDN a Webmaker vyžadují založení účtu, abyste mohli zasílat obsah vývojáře, odesílat uživatelské recenze či komentáře či instalovat určité typy aplikací. V souvislosti se svým účtem vám mohou být pravidelně zasílány e-maily.
 
 * **Uživatelská zpětná vazba**:  Zpětnou vazbu týkající se našich produktů a služeb nám můžete poskytovat na webových stránkách jako např. [input.mozilla.org](https://input.mozilla.org/), prostřednictvím integrovaných dotazníků na zkušenosti s produktem nebo prostřednictvím kanálů jako např. e-mail, Bugzilla, IRC, účet na sociálních médiích nebo stránky Get Involved nebo prostřednictvím skupiny jako např. Student Ambassadors. Omezte prosím na minimum osobní údaje, které budete na těchto fórech sdílet, protože vaše komentáře budou veřejně přístupné.
 
 ---------------------------------------
 
-Pro zajištění funkčnosti a vylepšení našich produktů, služeb a komunikace používáme soubory cookies, jednopixelové gify, nezávislou webovou analýzu a IP adresy . 
+Pro zajištění funkčnosti a vylepšení našich produktů, služeb a komunikace používáme soubory cookies, jednopixelové gify, nezávislou webovou analýzu a IP adresy.
 {: #data-tools }
 
-* **Funkce**: Můžeme používat soubory cookie, informace a zařízení a adresy IP pro rozšíření funkcí některých produktů, služeb a sdělení. Například:
-    * Soubory cookie se používají, abychom si zapamatovali vaše jazykové předvolby Firefox a doplňky Firefox. Pomáhají i při přihlašování a ověřování uživatele, takže na některých webových stránkách Mozilla se můžete obejít bez zadávání hesel.  
-    * Adresy IP se používají pro přizpůsobení sdělení jazyku a zemi.  
+* **Funkce**: Můžeme používat soubory cookie, informace a zařízení a IP adresy pro rozšíření funkcí některých produktů, služeb a sdělení. Například:
+    * Soubory cookie se používají, abychom si zapamatovali vaše jazykové předvolby Firefoxu a doplňky Firefoxu. Pomáhají i při přihlašování a ověřování uživatele, takže na některých webových stránkách Mozilla se můžete obejít bez zadávání hesel.
+    * IP adresy se používají pro přizpůsobení sdělení jazyku a zemi.
     * Informace o zařízení, jako např. země, jazyk, operátor a OEM mohou být využity pro přizpůsobení vaší interakce na Firefox Marketplace a Webmaker.
 
-* **Metriky**: Můžeme rovněž využívat soubory cookies, informace o zařízení a adresách IP, společně s prázdnými GIFy, soubory cookies a službami třetích osob, které nám pomáhají pochopit, jak souhrnně uživatelé pracují s našimi produkty, službami, komunikacemi, webovými stránkami, online kampaněmi, snippety, zařízeními a dalšími platformami. Používáme:
-    * Google Analytics, která umisťuje soubory cookie do vašeho zařízení pro získání metrik toho, jak uživatelé využívají naše webové stránky.      To nám pomáhá vylepšovat obsah stránek.  
-    * Optimizely a ShareProgress, které umisťují soubory cookie do vašeho zařízení, které nám pomáhají testovat změny obsahu webu.  To nám pomáhá nabízet uživatelům lepší zkušenosti s webem.
-    * DoubleClick a Flashtalking, z nichž každá využívá čisté GIFy na stránkách stahování Firefox.  To nám pomáhá měřit efektivitu našich reklamních kampaní.
-    * Yahoo Dot Pixel, která využívá JavaScript na našich stránkách stahování Firefox. To nám pomáhá měřit efektivitu našich reklamních kampaní. 
-    * Referenční data HTTP, která mohou být součástí instalačního programu Firefox, které nám pomáhají pochopit domény webových stránek nebo reklamní kampaně, které vás na stránku stahování přivedly. Tato informace nám pomáhá pochopit efektivitu našich reklamních kampaní a jejich vylepšování.
-    * Další nástroje metriky čas od času, na experimentální bázi. Například to mžeme využít jako pomůcku pro hodnocení nových nástrojů metriky nebo testování stávající shromážděné metriky.
+* **Metriky**: Můžeme rovněž využívat soubory cookies, informace o zařízení a IP adresách, společně s prázdnými GIFy, soubory cookies a službami třetích osob, které nám pomáhají pochopit, jak souhrnně uživatelé pracují s našimi produkty, službami, sděleními, webovými stránkami, online kampaněmi, snippety, zařízeními a dalšími platformami. Používáme:
+    * Google Analytics, které umisťují soubory cookie do vašeho zařízení pro získání metrik toho, jak uživatelé využívají naše webové stránky. To nám pomáhá vylepšovat obsah stránek.
+    * Optimizely a ShareProgress, které umisťují soubory cookie do vašeho zařízení, které nám pomáhají testovat změny obsahu webu. To nám pomáhá nabízet uživatelům lepší prožitek na webu.
+    * DoubleClick a Flashtalking, z nichž každá využívá prázdné GIFy na stránkách stahování Firefoxu. To nám pomáhá měřit efektivitu našich reklamních kampaní.
+    * Yahoo Dot Pixel, která využívá JavaScript na našich stránkách stahování Firefoxu. To nám pomáhá měřit efektivitu našich reklamních kampaní.
+    * Referenční data HTTP, která mohou být součástí instalačního programu Firefoxu, které nám pomáhají zjistit domény webových stránek nebo reklamní kampaně, které vás na stránku stahování přivedly. Tato informace nám pomáhá pochopit efektivitu našich reklamních kampaní a jejich vylepšování.
+    * Čas od času další nástroje a metriky, na experimentální bázi. Můžeme je využít např. jako pomůcku pro hodnocení nových nástrojů metriky nebo testování stávajících metriky.
 
 ---------------------------------------
 
-Můžete ovládat jednotlivé předvolby pro soubory cookies, informovat o svých předvolbách pro soubory cookies ostatní, jakož i rušit volby webové analýzy a nástrojů optimalizace. 
+Můžete ovládat jednotlivé předvolby pro soubory cookies, informovat o svých předvolbách pro soubory cookies ostatní, jakož i rušit volby webové analýzy a nástrojů optimalizace.
 {: #user-choices }
 
-* **Historie souborů cookie**: Jednotlivé soubory cookies můžete přijmout nebo odmítnout v preferencích aplikace Firefox pod položkou Historie v části Nástroje/Možnosti/Soukromí. Dovolujeme si upozornit, že některé funkce našich produktů a služeb nemusí bez pomoci souborů cookies správně fungovat.
+* **Historie souborů cookies**: Jednotlivé soubory cookies můžete přijmout nebo odmítnout v předvolbách Firefoxu pod položkou Historie v části Nástroje > Možnosti > Soukromí. Dovolujeme si upozornit, že některé funkce našich produktů a služeb nemusí bez pomoci souborů cookies správně fungovat.
 
-* **Nesledovat**: Mozilla nesleduje uživatele prostřednictvím webových stránek třetích osob pro zasílání cílené reklamy Pokud máte váš prohlížeč při vstupu na webové stránky nakonfigurovaný s nastavením signálu „Nesledovat”, Mozilla nebude používat žádný z nástrojů popsaných v části [Metriky](#data-tools) section.  
+* **Funkce Do Not Track**: Mozilla nesleduje uživatele prostřednictvím webových stránek třetích osob pro zasílání cílené reklamy. Pokud máte váš prohlížeč při vstupu na webové stránky nakonfigurovaný s nastavením signálu „Do Not Track”, Mozilla nebude používat žádný z nástrojů popsaných v části [Metriky](#data-tools).
 
-* **E-mail**: Přijímání našich marketingových sdělení je dobrovolné a ze služby se můžete odhlásit v zápatí e-mailu nebo prostřednictvím aktualizace vašich [e-mailových preferencí v aplikaci Mozilla](https://www.mozilla.org/newsletter/recovery/).
+* **E-mail**: Přijímání našich marketingových sdělení je dobrovolné a ze služby se můžete odhlásit v zápatí e-mailu nebo prostřednictvím aktualizace vašich [e-mailových předvoleb v aplikaci Mozilla](https://www.mozilla.org/newsletter/recovery/).
 
 * **Analýza a optimalizace**: Pro zabránění shromažďování dat o vašich návštěvách webových stránek Mozilla postupujte dle pokynů níže:
-    *  Google: Nainstalujte [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout), který zachová anonymitu vašich návštěv a zakáže přenos dat do Google Analytics. Některé stránky Mozilla.org používají čisté soubory GIF, které komunikují s DoubleClick, aby umožnily pochopit účinnost našich reklamních kampaní; přizpůsobené reklamy z DoubleClick mžete ovládat v nastavení reklamy Google (budete vyzváni k přihlášení k vašemu účtu Google).
-    *  Optimizely: [Zrušte odběr v www.mozilla.org](https://www.mozilla.org/?optimizely_opt_out=true) nebo navštivte [webové stránky zrušení odběru Optimizely](https://www.optimizely.com/opt_out), kde najdete podrobnější informace.
-    *  Yahoo: pro zrušení volby navštivte [Správné reklamních zájmů](https://aim.yahoo.com/aim/us/en/optout/).
-    *  ShareProgress: V prohlížeči můžete [zapnout funkci Nesledovat](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature).
+    *  Google: Nainstalujte [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout), který zachová anonymitu vašich návštěv a zakáže přenos dat do Google Analytics. Některé stránky Mozilla.org používají čisté soubory GIF, které komunikují s DoubleClick, aby umožnily pochopit účinnost našich reklamních kampaní; přizpůsobené reklamy z DoubleClick můžete ovládat v nastavení reklamy Google (budete vyzváni k přihlášení k vašemu účtu Google).
+    *  Optimizely: [Zrušte odběr na www.mozilla.org](https://www.mozilla.org/?optimizely_opt_out=true) nebo navštivte [webové stránky zrušení odběru Optimizely](https://www.optimizely.com/opt_out), kde najdete podrobnější informace.
+    *  Yahoo: pro zrušení volby navštivte [Správce reklamních zájmů](https://aim.yahoo.com/aim/us/en/optout/).
+    *  ShareProgress: V prohlížeči můžete [zapnout funkci Do Not Track](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature).
 
-* **Sociální média**: Tlačítka pro sdílení na sociálních sítích na webových stránkách Mozilla jsou navržena tak, aby údaje nebyly sdíleny s poskytovatelem sociálních médií, dokud na tlačítko přímo nekliknete.
+* **Sociální média**: Tlačítka pro sdílení na sociálních sítích na webových stránkách Mozilly jsou navržena tak, aby údaje nebyly sdíleny s poskytovatelem sociálních médií, dokud na tlačítko přímo nekliknete.
 
 ---------------------------------------
 
-Některé webové stránky Mozilla umožňují provádět nákupy (např. aplikací nebo zboží) nebo poskytovat dary. Tyto transakce jsou zpracovávány třetími stranami a nikoli společností Mozilla. 
+Některé webové stránky Mozilly umožňují provádět nákupy (např. aplikací nebo zboží) nebo poskytovat dary. Tyto transakce jsou zpracovávány třetími stranami a nikoli společností Mozilla.
 {: #donations }
 
-* **Zpracovávání plateb**:   Společnost Mozilla nezískává žádné finanční informace, které jsou vámi předávány ke zpracování našim nezávislým dodavatelům. Název třetí strany se zobrazí v okamžiku transakce.  
+* **Zpracovávání plateb**: Společnost Mozilla nezískává žádné bankovní informace, které jsou vámi předávány ke zpracování našim nezávislým dodavatelům. Název třetí strany se zobrazí v okamžiku transakce.

--- a/websites_privacy_notice/cs.md
+++ b/websites_privacy_notice/cs.md
@@ -18,7 +18,7 @@ Může se stát, že během vaší interakce s námi na platformách sociálníc
 
 * **Přispěvatelé**: Budete-li spolupracovat se společností Mozilla jako dobrovolný přispěvatel v rámci komunity, může být případně zapotřebí, aby s vámi společnost Mozilla a jiné subjekty komunikovaly přes e-mailovou adresu, kterou v souvislosti se svým příspěvkem poskytnete, a také za účelem uznání vašeho úsilí. Podílíte-li se na aplikacích Bugzilla, Mozilla Reps nebo na zdrojovém kódu, budou vaše e-mailová adresa a případně i vaše jméno veřejně k dispozici všem uživatelům internetu. Vytvoříte-li si profil na Mozillians.org, bude tento profil přístupný pro zaměstnance a spolupracovníky společnosti Mozilla. Údaje na vašem profilu můžete upravovat pomocí [Nastavení profilu](https://mozillians.org/user/edit). Někdy využíváme údaje o spolupracovnících ze zdrojů (např. Bugzilla) na panelech pro vizuální sdílení souhrnných dat o komunitě Mozilla. Příkladem je [https://wiki.mozilla.org/Contribute/Dashboards](https://wiki.mozilla.org/Contribute/Dashboards). Je-li to možné, snažíme se veřejně zobrazované kontaktní údaje omezit na minimum.
 
-* **Účty**: Některé webové stránky jako například Marketplace, AMO, MDN a Webmaker vyžadují založení účtu, abyste mohli zasílat obsah vývojáře, odesílat uživatelské recenze či komentáře či instalovat určité typy aplikací. V souvislosti se svým účtem vám mohou být pravidelně zasílány e-maily.
+* **Účty**: Některé webové stránky jako například Marketplace, AMO, MDN a Webmaker vyžadují založení účtu, aby vývojáři mohli nahrávat svůj obsah, uživatelé odesílat recenze či komentáře či instalovat určité typy aplikací. V souvislosti se svým účtem vám mohou být pravidelně zasílány e-maily.
 
 * **Uživatelská zpětná vazba**:  Zpětnou vazbu týkající se našich produktů a služeb nám můžete poskytovat na webových stránkách jako např. [input.mozilla.org](https://input.mozilla.org/), prostřednictvím integrovaných dotazníků na zkušenosti s produktem nebo prostřednictvím kanálů jako např. e-mail, Bugzilla, IRC, účet na sociálních médiích nebo stránky Get Involved nebo prostřednictvím skupiny jako např. Student Ambassadors. Omezte prosím na minimum osobní údaje, které budete na těchto fórech sdílet, protože vaše komentáře budou veřejně přístupné.
 
@@ -27,18 +27,18 @@ Může se stát, že během vaší interakce s námi na platformách sociálníc
 Pro zajištění funkčnosti a vylepšení našich produktů, služeb a komunikace používáme soubory cookies, jednopixelové gify, nezávislou webovou analýzu a IP adresy.
 {: #data-tools }
 
-* **Funkce**: Můžeme používat soubory cookie, informace a zařízení a IP adresy pro rozšíření funkcí některých produktů, služeb a sdělení. Například:
-    * Soubory cookie se používají, abychom si zapamatovali vaše jazykové předvolby Firefoxu a doplňky Firefoxu. Pomáhají i při přihlašování a ověřování uživatele, takže na některých webových stránkách Mozilla se můžete obejít bez zadávání hesel.
+* **Funkce**: Můžeme používat soubory cookies, informace a zařízení a IP adresy pro rozšíření funkcí některých produktů, služeb a sdělení. Například:
+    * Soubory cookies se používají, abychom si zapamatovali vaše jazykové předvolby Firefoxu a doplňky Firefoxu. Pomáhají i při přihlašování a ověřování uživatele, takže na některých webových stránkách Mozilla se můžete obejít bez zadávání hesel.
     * IP adresy se používají pro přizpůsobení sdělení jazyku a zemi.
     * Informace o zařízení, jako např. země, jazyk, operátor a OEM mohou být využity pro přizpůsobení vaší interakce na Firefox Marketplace a Webmaker.
 
 * **Metriky**: Můžeme rovněž využívat soubory cookies, informace o zařízení a IP adresách, společně s prázdnými GIFy, soubory cookies a službami třetích osob, které nám pomáhají pochopit, jak souhrnně uživatelé pracují s našimi produkty, službami, sděleními, webovými stránkami, online kampaněmi, snippety, zařízeními a dalšími platformami. Používáme:
-    * Google Analytics, které umisťují soubory cookie do vašeho zařízení pro získání metrik toho, jak uživatelé využívají naše webové stránky. To nám pomáhá vylepšovat obsah stránek.
-    * Optimizely a ShareProgress, které umisťují soubory cookie do vašeho zařízení, které nám pomáhají testovat změny obsahu webu. To nám pomáhá nabízet uživatelům lepší prožitek na webu.
+    * Google Analytics, které umisťují soubory cookies do vašeho zařízení pro získání metrik toho, jak uživatelé využívají naše webové stránky. To nám pomáhá vylepšovat obsah stránek.
+    * Optimizely a ShareProgress, které umisťují soubory cookies do vašeho zařízení, které nám pomáhají testovat změny obsahu webu. To nám pomáhá nabízet uživatelům lepší prožitek na webu.
     * DoubleClick a Flashtalking, z nichž každá využívá prázdné GIFy na stránkách stahování Firefoxu. To nám pomáhá měřit efektivitu našich reklamních kampaní.
     * Yahoo Dot Pixel, která využívá JavaScript na našich stránkách stahování Firefoxu. To nám pomáhá měřit efektivitu našich reklamních kampaní.
     * Referenční data HTTP, která mohou být součástí instalačního programu Firefoxu, které nám pomáhají zjistit domény webových stránek nebo reklamní kampaně, které vás na stránku stahování přivedly. Tato informace nám pomáhá pochopit efektivitu našich reklamních kampaní a jejich vylepšování.
-    * Čas od času další nástroje a metriky, na experimentální bázi. Můžeme je využít např. jako pomůcku pro hodnocení nových nástrojů metriky nebo testování stávajících metriky.
+    * Čas od času další nástroje a metriky, na experimentální bázi. Můžeme je využít např. jako pomůcku pro hodnocení nových nástrojů pro metriky nebo testování stávajících metrik.
 
 ---------------------------------------
 


### PR DESCRIPTION
- Zásady ochrany osobních údajů společnosti Mozilla -> Zásady ochrany soukromí (real name of the document, Mozilla is defined by the context and the preceding naše = our)

All the other updates are mostly about typos, slight style improvements and terminology. No big issues like completely wrong translations found.