### PR TITLE
[cs] Update Privacy Notice/Policy terminology, some small updates

### DIFF
--- a/Common_Voice_Privacy_Notice/cs.md
+++ b/Common_Voice_Privacy_Notice/cs.md
@@ -4,16 +4,16 @@ Platné od ⁨19. června 2017⁩ {: datetime="2017-06-19" }
 
 ## Osobní údaje
 
-Když Mozilla (to jsme my) získává informace od vás, naše [Zásady ochrany osobních údajů](https://www.mozilla.org/privacy) popisuje, jak s těmito daty nakládáme.
+Když Mozilla (to jsme my) získává informace od vás, naše [Zásady ochrany osobních údajů](https://www.mozilla.org/privacy) popisují, jak s těmito daty nakládáme.
 
 * **Demografická data.** Dobrovolně nám můžete odeslat informace, jako je váš přízvuk, věk a pohlaví. To pomáhá nám a ostatním výzkumníkům zlepšovat a vytvářet technologie a nástroje pro převod řeči na text.
 
-* **Informace o účtu.** Dobrovolně si můžete vytvořit účet, přičemž my obdržíme vaši e-mailovou adresu. Ta je spojená s vašimi demografickými a interakčními daty, ale není dostupná pro veřejnost.
+* **Informace o účtu.** Dobrovolně si můžete vytvořit účet, přičemž obdržíme vaši e-mailovou adresu. Ta je spojená s vašimi demografickými a daty o interakcích, ale není veřejně dostupná.
 
-* **Hlasové nahrávky.** Hlasové nahrávky, spolu s jakýmykoli demografickými daty, mohou být dostupné v databázi Common Voice pro veřejné využití.
+* **Hlasové nahrávky.** Hlasové nahrávky, spolu s demografickými daty, mohou být dostupné v databázi Common Voice pro veřejné využití.
 
-* **Interakční data.** Používáme Google Analytics, abychom lépe pochopili, jak pracujete s aplikací nebo webem Common Voice. To zahrnuje například počet zvukových nahrávek, které jste nahráli nebo poslechli, interakce s tlačítky a menu, nebo délku relace.
+* **Data o interakcích.** Používáme Google Analytics, abychom lépe pochopili, jak pracujete s aplikací nebo webem Common Voice. To zahrnuje například počet zvukových nahrávek, které jste nahráli nebo poslechli, interakce s tlačítky a nabídkami, nebo délku relace.
 
-* **Technická data.** Pomocí Google Analytics sbíráme adresy URL a názvy stránek Common Voice, které navštěvujete. Sbíráme také typ vašeho prohlížeče, velikost zobrazení a rozlišení obrazovky. Také sbíráme vaši polohu a nastavení jazyka ve vašem prohlížeči.
+* **Technická data.** Pomocí Google Analytics sbíráme URL adresy a názvy stránek Common Voice, které navštěvujete. Sbíráme také typ vašeho prohlížeče, velikost zobrazení a rozlišení obrazovky. Také sbíráme vaši polohu a nastavení jazyka ve vašem prohlížeči.
 
-[Zjistit více](https://github.com/mozilla/voice-web/blob/master/docs/data_dictionary.md)
+[Více informací](https://github.com/mozilla/voice-web/blob/master/docs/data_dictionary.md)

--- a/Common_Voice_Privacy_Notice/cs.md
+++ b/Common_Voice_Privacy_Notice/cs.md
@@ -1,10 +1,10 @@
-# Zásady ochrany soukromí projektu Common Voice
+# Zásady ochrany osobních údajů projektu Common Voice
 
 Platné od ⁨19. června 2017⁩ {: datetime="2017-06-19" }
 
-## Soukromí
+## Osobní údaje
 
-Když Mozilla (to jsme my) získává informace od vás, naše [Zásady ochrany soukromí](https://www.mozilla.org/privacy) popisuje, jak s těmito daty nakládáme.
+Když Mozilla (to jsme my) získává informace od vás, naše [Zásady ochrany osobních údajů](https://www.mozilla.org/privacy) popisuje, jak s těmito daty nakládáme.
 
 * **Demografická data.** Dobrovolně nám můžete odeslat informace, jako je váš přízvuk, věk a pohlaví. To pomáhá nám a ostatním výzkumníkům zlepšovat a vytvářet technologie a nástroje pro převod řeči na text.
 

--- a/Common_Voice_Terms/cs.md
+++ b/Common_Voice_Terms/cs.md
@@ -6,9 +6,9 @@ Platné od ⁨19. června 2017⁩ {: datetime="2017-06-19" }
 
 Musíte být starší 13 let nebo mít svolení rodiče či opatrovníka, který na vás v našem projektu musí dohlížet.
 
-## Soukromí
+## Osobní údaje
 
-Naše [Zásady ochrany soukromí](https://voice.allizom.org/privacy) vysvětlují, jak přijímáme a nakládáme s vašimi daty.
+Naše [Zásady ochrany osobních údajů](https://voice.allizom.org/privacy) vysvětlují, jak přijímáme a nakládáme s vašimi daty.
 
 ## Vaše příspěvky a uvolnění práv
 
@@ -16,7 +16,7 @@ Odesláním vašich nahrávek se vzdáváte všech autorských práv a souvisej�
 
 ## Komunikace
 
-Pokud se přihlásíte k odběru našeho zpravodaje nebo si v souvislosti s projektem Common Voice vytvoříte účet, můžete od nás dostávat e-maily spojené s vaším účtem (například aktualizace podmínek, zásad ochrany soukromí a bezpečnostních informací).
+Pokud se přihlásíte k odběru našeho zpravodaje nebo si v souvislosti s projektem Common Voice vytvoříte účet, můžete od nás dostávat e-maily spojené s vaším účtem (například aktualizace podmínek, zásad ochrany osobních údajů a bezpečnostních informací).
 
 ## Obecné
 
@@ -28,7 +28,7 @@ V ROZSAHU POVOLENÉM PŘÍSLUŠNÝM ZÁKONEM SOUHLASÍTE S UPUŠTĚNÍM OD PRÁV
 
 KROMĚ PŘÍPADŮ, KDY TO VYŽADUJE ZÁKON, MOZILLA A STRANY MOZILLY NEBUDOU ODPOVĚDNÍ ZA JAKÉKOLI NEPŘÍMÉ, SPECIÁLNÍ, NÁHODNÉ, NÁSLEDNÉ NEBO EXEMPLÁRNÍ ŠKODY VYPLÝVAJÍCÍ NEBO JAKKOLI SPOJENÉ S TĚMITO PODMÍNKAMI NEBO POUŽITÍM NEBO NEMOŽNOSTÍ POUŽITÍ SLUŽEB, VČETNĚ PŘÍMÉHO A NEPŘÍMÉHO POŠKOZENÍ NEBO ZTRÁTY POVĚSTI, ZASTAVENÍ PRÁCE, ZTRÁTY ZISKU, ZTRÁTY DAT A SELHÁNÍ POČÍTAČE NEBO JEHO SELHÁNÍ, A TO I KDYŽ BUDETE NA MOŽNOST TAKOVÝCH ŠKOD UPOZORNĚNI, BEZ OHLEDU NA PODKLADY (SMLOUVU, ČIN A OSTATNÍ), NA KTERÝCH JE TAKOVÝ NÁROK POSTAVEN. SOUHRNNÁ ODPOVĚDNOST MOZILLY A STRAN MOZILLY PODLE TÉTO DOHODY NEPŘEKROČÍ $500 (PĚT SET DOLARŮ). NĚKTERÉ JURISDIKCE NEUMOŽŇUJÍ VYLOUČENÍ NEBO OMEZENÍ NÁHODNÉ, NÁSLEDNÉ NEBO SPECIÁLNÍ ŠKODY, TAKŽE SE VÁS TOTO VYLOUČENÍ A OMEZENÍ NEMUSÍ VZTAHOVAT.
 
-## Aktualizace 
+## Aktualizace
 
 Mozilla může tyto Podmínky čas od času aktualizovat, aby zahrnula novou funkci Služeb nebo ujasnila ustanovení. Aktualizované Podmínky budou zveřejněny online. Pokud jsou změny postatné, oznámíme je přes běžné kanály Mozilly pro taková oznámení, jako jsou příspěvky na blogu nebo fóra. Vaším dalším používáním Služeb po datu platnosti změn vyjadřujete souhlas s těmito změnami. Abychom udělali kontrolu jednodušší, zveřejníme datum platnosti na začátek této stránky.
 

--- a/Common_Voice_Terms/cs.md
+++ b/Common_Voice_Terms/cs.md
@@ -30,7 +30,7 @@ KROMĚ PŘÍPADŮ, KDY TO VYŽADUJE ZÁKON, MOZILLA A STRANY MOZILLY NEBUDOU ODP
 
 ## Aktualizace
 
-Mozilla může tyto Podmínky čas od času aktualizovat, aby zahrnula novou funkci Služeb nebo ujasnila ustanovení. Aktualizované Podmínky budou zveřejněny online. Pokud jsou změny postatné, oznámíme je přes běžné kanály Mozilly pro taková oznámení, jako jsou příspěvky na blogu nebo fóra. Vaším dalším používáním Služeb po datu platnosti změn vyjadřujete souhlas s těmito změnami. Abychom udělali kontrolu jednodušší, zveřejníme datum platnosti na začátek této stránky.
+Mozilla může tyto Podmínky čas od času aktualizovat, aby zahrnula novou funkci Služeb nebo ujasnila ustanovení. Aktualizované Podmínky budou zveřejněny online. Pokud jsou změny podstatné, oznámíme je přes běžné kanály Mozilly pro taková oznámení, jako jsou příspěvky na blogu nebo fóra. Vaším dalším používáním Služeb po datu platnosti změn vyjadřujete souhlas s těmito změnami. Abychom udělali kontrolu jednodušší, zveřejníme datum platnosti na začátek této stránky.
 
 ## Ukončení
 

--- a/firefox_cloud_services_ToS/cs.md
+++ b/firefox_cloud_services_ToS/cs.md
@@ -27,7 +27,7 @@ Tato úvodní část je shrnutím níže uvedených ustanovení. Toto shrnutí s
 
     Služba Firefox Screenshots vám umožňuje snímat obsah webových stránek, který si můžete později prohlížet vy sami či jiní lidé. [Zde](https://www.mozilla.org/about/legal/report-infringement/) můžete nahlásit nároky k porušení autorských práv nebo ochranných známek ve službě Screenshots. Pro nahlášení zneužití nám zašlete odkaz na snímek na adresu screenshots-report@mozilla.com.
 
-4. #### Zásady ochrany soukromí
+4. #### Zásady ochrany osobních údajů
 
     [Oznámení o ochraně osobních údajů Firefox](https://www.mozilla.org/privacy/firefox/) popisuje, co získáváme z vašeho používání Služeb, a jak tyto informace používáme. Informace, které získáváme prostřednictvím Služeb, jsou popsány v našich [Zásadách ochrany osobních údajů](https://www.mozilla.org/privacy/).
 
@@ -70,8 +70,8 @@ Tato úvodní část je shrnutím níže uvedených ustanovení. Toto shrnutí s
     Kontaktujte společnost Mozilla na adrese
 
     <address>
-      Mozilla Corporation 
-      k rukám: Mozilla – Legal Notices 
-      331 E. Evelyn Ave., 
-      Mountain View, CA 94041 
+      Mozilla Corporation
+      k rukám: Mozilla – Legal Notices
+      331 E. Evelyn Ave.,
+      Mountain View, CA 94041
     </address>

--- a/mozilla_privacy_policy/cs.md
+++ b/mozilla_privacy_policy/cs.md
@@ -1,9 +1,9 @@
-﻿# Zásady ochrany soukromí společnosti Mozilla
+﻿# Zásady Mozilly pro ochranu osobních údajů
 
 15\. dubna 2014
 {: datetime="2014-04-15" }
 
-Vaše soukromí představuje důležitý faktor, k němuž společnost Mozilla (tedy my) přihlíží při vývoji každého z našich produktů a služeb. Náš závazek je být transparentní a otevření. Tyto Zásady ochrany soukromí společnosti Mozilla obecně vysvětlují jak získáváme informace o vás a co s těmito informacemi po jejich získání děláme. Můžete si rovněž přečíst naše oznámení o ochraně soukromí pro produkt a nejčastější dotazy, kde získáte podrobnější informace týkající se našich jednotlivých produktů a služeb.
+Vaše soukromí představuje důležitý faktor, k němuž společnost Mozilla (tedy my) přihlíží při vývoji každého z našich produktů a služeb. Náš závazek je být transparentní a otevření. Tyto zásady ochrany osobních údajů obecně vysvětlují jak získáváme informace o vás a co s těmito informacemi po jejich získání děláme. Můžete si rovněž přečíst naše zásady ochrany ochranu osobních údajů pro produkt a nejčastější dotazy, kde získáte podrobnější informace týkající se našich jednotlivých produktů a služeb.
 
 ## Co máme na mysli pod pojmem „osobní údaje”?
 
@@ -43,10 +43,10 @@ Vaše osobní údaje nechceme uchovávat po dobu delší než je nezbytná, tak�
 
 ## Co byste měli dále vědět?
 
-Jsme globální organizací a naše počítače se nacházejí na několika různých místech po celém světě. Využíváme rovněž poskytovatele služeb, jejichž počítače se mohou rovněž nacházet v různých zemích. To znamená, že vaše údaje mohou skončit v některém z těchto počítačů v jiné zemi a daná země může nabízet jinou míru ochrany dat než vaše země. Pokud nám poskytnete informace, souhlasíte s tímto druhem převodu vašich údajů. Bez ohledu na to, v jaké zemi se vaše údaje nacházejí, dodržujeme platné právo a veškeré závazky, které uvádíme v těchto zásadách ochrany soukromí.
+Jsme globální organizací a naše počítače se nacházejí na několika různých místech po celém světě. Využíváme rovněž poskytovatele služeb, jejichž počítače se mohou rovněž nacházet v různých zemích. To znamená, že vaše údaje mohou skončit v některém z těchto počítačů v jiné zemi a daná země může nabízet jinou míru ochrany dat než vaše země. Pokud nám poskytnete informace, souhlasíte s tímto druhem převodu vašich údajů. Bez ohledu na to, v jaké zemi se vaše údaje nacházejí, dodržujeme platné právo a veškeré závazky, které uvádíme v těchto zásadách ochrany osobních údajů.
 
 Jste-li mladší 13 let, nemáme zájem o vaše osobní údaje, a vy nám je nesmíte poskytovat. Pokud jste rodič a domníváte se, že vaše dítě mladší 13 let nám poskytlo osobní údaje, [kontaktujte nás](https://www.mozilla.org/privacy/#contact) prosím, abychom údaje vašeho dítěte odstranili.
 
-## Co se stane, když změníme tyto zásady ochrany soukromí nebo kterékoliv z našich oznámení o ochraně soukromí?
+## Co se stane, když změníme tyto nebo kterékoliv jiné zásady ochrany osobních údajů?
 
 Možná budeme potřebovat tyto zásady a naše oznámení změnit. Aktualizace budou zveřejněny online. Budou-li změny zásadního charakteru, aktualizaci oznámíme prostřednictvím obvyklých kanálů společnosti Mozilla pro taková oznámení, jako jsou příspěvky na blozích a fórech. Budete-li produkt či službu dále používat po datu účinnosti takových změn, bude to znamenat váš souhlas s takovými změnami. Abyste měli lepší přehled o verzích, datum účinnosti budeme uvádět v horní části stránky.


### PR DESCRIPTION
Bug 1322386 - Update Privacy Notice/Policy terminology (to "Zásady ochrany osobních údajů")
Other changes:
- `popisuje` -> `popisují`: grammar
- `interakční data` -> `data o interakcích`: better form of the grammatical attribute
- `dostupná pro veřejnost` -> `veřejně dostupná`: natural formulation
- `menu`-> `nabídkami`: better Czech word
- `Zjistit více` -> `Více informací`: In the context of a document this looks better.