### PR TITLE
Fix bug 1487154: Update links to firefox-source-docs.mozilla.org

### DIFF
--- a/firefox-cliqz_privacy_notice/de.md
+++ b/firefox-cliqz_privacy_notice/de.md
@@ -17,7 +17,7 @@ In diesem Datenschutzhinweis erklären wir, welche Daten Firefox teilt und verwe
 
 * __Technische Daten__: Firefox sendet Daten über Firefox-Version und Sprache, Gerätebetriebssystem und Hardware-Konfiguration, Speicher, grundlegende Informationen über Systemabstürze und Fehler, Ergebnisse automatisierter Prozesse wie z. B. Updates, SafeBrowsing und Aktivierung an uns.  Wenn Firefox Daten an uns sendet, wird Ihre IP-Adresse kurzzeitig als Teil unserer Server-Logs erfasst.
 
-Lesen Sie die Telemetrie-Dokumentation für [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) oder [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) bzw. erfahren Sie, wie Sie diese Datenerfassung per [Opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) einstellen können.
+Lesen Sie die Telemetrie-Dokumentation für [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) oder [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) bzw. erfahren Sie, wie Sie diese Datenerfassung per [Opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) einstellen können.
 {: #telemetry }
 
 ### Festlegen eines Standardsuchanbieters {: #defaultsearch }

--- a/firefox-cliqz_privacy_notice/en-US.md
+++ b/firefox-cliqz_privacy_notice/en-US.md
@@ -17,7 +17,7 @@ In this Privacy Notice, we explain what data Firefox shares and point you to set
 
 * __Technical data__: Firefox sends data about your Firefox version and language; device operating system and hardware configuration; memory, basic information about crashes and errors; outcome of automated processes like updates, safebrowsing, and activation to us.  When Firefox sends data to us, your IP address is temporarily collected as part of our server logs.
 
-Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), or [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) or learn how to [opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) of this data collection.
+Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), or [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) or learn how to [opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) of this data collection.
 {: #telemetry }
 
 ### Set a default search provider {: #defaultsearch }

--- a/firefox_privacy_notice/cs.md
+++ b/firefox_privacy_notice/cs.md
@@ -17,7 +17,7 @@ V tomto Prohlášení o ochraně osobních údajů vysvětlujeme, jaké údaje F
 
 * __Technické údaje__: Firefox nám zasílá údaje o vaší verzi a jazyce Firefoxu; operačním systému zařízení a konfiguraci hardwaru; paměti, základních informací o pádech a chybách; výsledku automatizovaných procesů, jako jsou aktualizace, bezpečné procházení a aktivace.  Když nám Firefox zasílá údaje, dočasně se v protokolu našeho serveru shromažďuje vaše adresa IP.  
 
-Přečtěte si dokumentaci o telemetrii pro [stolní počítače](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) nebo [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) nebo si přečtěte, jak  [zrušit volbu](https://support.mozilla.org/kb/send-performance-data-improve-firefox) shromažďování těchto údajů.
+Přečtěte si dokumentaci o telemetrii pro [stolní počítače](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) nebo [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) nebo si přečtěte, jak  [zrušit volbu](https://support.mozilla.org/kb/send-performance-data-improve-firefox) shromažďování těchto údajů.
 {: #telemetry }
 
 ### Nastavení výchozího poskytovatele vyhledávání {: #defaultsearch }

--- a/firefox_privacy_notice/de.md
+++ b/firefox_privacy_notice/de.md
@@ -17,7 +17,7 @@ In diesem Datenschutzhinweis erklären wir, welche Daten Firefox teilt und verwe
 
 * __Technische Daten__: Firefox sendet Daten über Firefox-Version und Sprache, Gerätebetriebssystem und Hardware-Konfiguration, Speicher, grundlegende Informationen über Systemabstürze und Fehler, Ergebnisse automatisierter Prozesse wie z. B. Updates, SafeBrowsing und Aktivierung an uns.  Wenn Firefox Daten an uns sendet, wird Ihre IP-Adresse kurzzeitig als Teil unserer Server-Logs erfasst.  
 
-Lesen Sie die Telemetrie-Dokumentation für [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) oder [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) bzw. erfahren Sie, wie Sie diese Datenerfassung per [Opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) einstellen können.
+Lesen Sie die Telemetrie-Dokumentation für [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) oder [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) bzw. erfahren Sie, wie Sie diese Datenerfassung per [Opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) einstellen können.
 {: #telemetry }
 
 ### Festlegen eines Standardsuchanbieters {: #defaultsearch }

--- a/firefox_privacy_notice/en-US.md
+++ b/firefox_privacy_notice/en-US.md
@@ -17,7 +17,7 @@ In this Privacy Notice, we explain what data Firefox shares and point you to set
 
 * __Technical data__: Firefox sends data about your Firefox version and language; device operating system and hardware configuration; memory, basic information about crashes and errors; outcome of automated processes like updates, safebrowsing, and activation to us.  When Firefox sends data to us, your IP address is temporarily collected as part of our server logs.  
 
-Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), or [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) or learn how to [opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) of this data collection.
+Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), or [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) or learn how to [opt-out](https://support.mozilla.org/kb/send-performance-data-improve-firefox) of this data collection.
 {: #telemetry }
 
 ### Set a default search provider {: #defaultsearch }

--- a/firefox_privacy_notice/es-ES.md
+++ b/firefox_privacy_notice/es-ES.md
@@ -17,7 +17,7 @@ En este Aviso de privacidad, especificamos qué datos comparte Firefox y los aju
 
 * __Datos técnicos__: Firefox nos envía datos sobre su versión e idioma de Firefox, sistema operativo y configuración de hardware del dispositivo, memoria, información básica sobre cierres y fallos, resultados de procesos automatizados como actualizaciones, navegación segura y activación.  Cuando Firefox nos envía datos, su dirección de IP se guarda temporalmente como parte de los registros del servidor.  
 
-Consulte la documentación de telemetría para [ordenadores de escritorio](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), o [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o visite esta página [](https://support.mozilla.org/kb/send-performance-data-improve-firefox)para obtener información sobre cómo deshabilitar la recopilación de datos.
+Consulte la documentación de telemetría para [ordenadores de escritorio](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), o [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o visite esta página [](https://support.mozilla.org/kb/send-performance-data-improve-firefox)para obtener información sobre cómo deshabilitar la recopilación de datos.
 {: #telemetry }
 
 ### Establece un proveedor de búsquedas predeterminado {: #defaultsearch }

--- a/firefox_privacy_notice/es-MX.md
+++ b/firefox_privacy_notice/es-MX.md
@@ -17,7 +17,7 @@ En este Aviso de privacidad, te explicamos qué datos comparte Firefox y te indi
 
 * __Datos técnicos__: Firefox nos envía datos sobre tu versión de Firefox y el idioma en el que lo usas; sistema operativo del dispositivo y configuración de hardware; memoria, información básica sobre fallos y errores; resultados de procesos automatizados como actualizaciones, navegación segura y activación.  Cuando Firefox nos envía datos, tu dirección IP se recoge temporalmente como parte de nuestros registros de servidor.  
 
-Lee la documentación de telemetría para dispositivos de [Escritorio](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), o [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o aprende cómo [salirte](https://support.mozilla.org/kb/send-performance-data-improve-firefox) de esta recopilación de datos.
+Lee la documentación de telemetría para dispositivos de [Escritorio](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), o [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o aprende cómo [salirte](https://support.mozilla.org/kb/send-performance-data-improve-firefox) de esta recopilación de datos.
 {: #telemetry }
 
 ### Configura un proveedor de búsqueda predeterminado {: #defaultsearch }

--- a/firefox_privacy_notice/fr.md
+++ b/firefox_privacy_notice/fr.md
@@ -17,7 +17,7 @@ Dans cette Politique de confidentialité, nous expliquons quelles données Firef
 
 * __Données techniques__ : Firefox nous envoie des données à propos de la version et de la langue de votre Firefox, du système d’exploitation de votre appareil et sa configuration matérielle, de la mémoire, des informations de base sur les plantages et les erreurs, le résultat de processus automatiques comme les mises à jour, le blocage de sites malveillants et l’activation. Lorsque Firefox nous envoie des données, votre adresse IP est temporairement collectée dans les fichiers journaux de nos serveurs.
 
-Lisez la documentation de télémétrie pour [ordinateur](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) ou [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) ou apprenez à [vous retirer](https://support.mozilla.org/kb/send-performance-data-improve-firefox) de cette collecte de données.
+Lisez la documentation de télémétrie pour [ordinateur](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) ou [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) ou apprenez à [vous retirer](https://support.mozilla.org/kb/send-performance-data-improve-firefox) de cette collecte de données.
 {: #telemetry }
 
 ### Définir un prestataire de recherche par défaut {: #defaultsearch }

--- a/firefox_privacy_notice/id.md
+++ b/firefox_privacy_notice/id.md
@@ -17,7 +17,7 @@ Dalam Kebijakan Privasi ini, kami menjelaskan apa saja data yang dibagikan Firef
 
 * __Data teknis__: Firefox mengirimkan data tentang versi dan bahasa Firefox Anda; sistem operasi perangkat dan konfigurasi perangkat keras; memori, informasi dasar tentang kerusakan dan kesalahan; hasil proses otomatis seperti pembaruan, penelusuran aman, dan aktivasi kepada kami.  Saat Firefox mengirimkan data kepada kami, alamat IP Anda akan sementara dikumpulkan sebagai bagian dari log server kami.  
 
-Baca dokumen telemetri untuk [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), atau [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) atau pelajari cara [menonaktifkan fitur](https://support.mozilla.org/kb/send-performance-data-improve-firefox) pengumpulan data ini.
+Baca dokumen telemetri untuk [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), atau [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) atau pelajari cara [menonaktifkan fitur](https://support.mozilla.org/kb/send-performance-data-improve-firefox) pengumpulan data ini.
 {: #telemetry }
 
 ### Mengatur penyedia pencarian baku {: #defaultsearch }

--- a/firefox_privacy_notice/it.md
+++ b/firefox_privacy_notice/it.md
@@ -17,7 +17,7 @@ In questo Avviso sulla privacy illustreremo quali sono i dati che Firefox condiv
 
 * __Dati tecnici__: Firefox ci invia dati sulla versione di Firefox e sulla lingua usata; sul sistema operativo del dispositivo e sulla configurazione hardware, sulla memoria, su informazioni di base su arresti anomali ed errori; sul risultato di processi automatici quali aggiornamenti, servizio di safebrowing e attivazione. Quando Firefox ci invia i dati, il vostro indirizzo IP viene temporaneamente raccolto quale parte dei log del nostro server.
 
-È possibile consultare la documentazione di telemetria per [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html), oppure per [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o scoprire come [non partecipare](https://support.mozilla.org/kb/send-performance-data-improve-firefox) a questa raccolta di dati.
+È possibile consultare la documentazione di telemetria per [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html), oppure per [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) o scoprire come [non partecipare](https://support.mozilla.org/kb/send-performance-data-improve-firefox) a questa raccolta di dati.
 {: #telemetry }
 
 ### Impostare un fornitore di servizi di ricerca predefinito {: #defaultsearch }

--- a/firefox_privacy_notice/ja.md
+++ b/firefox_privacy_notice/ja.md
@@ -17,7 +17,7 @@
 
 * __技術情報__: Firefox は、お使いの Firefox のバージョンおよび言語、端末のオペレーティングシステムとハードウェア構成、メモリー、クラッシュやエラーに関する基本的な情報、更新、セーフブラウジング、アクティベーションなどの自動化プロセスの結果を Mozilla に送信します。Firefox が Mozilla にデータを送信する際には、Mozilla のサーバーログの一部として、あなたの IP アドレスが一時的に収集されます。
 
-[デスクトップ](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html)、または [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) 用のパフォーマンス情報の送信に関するドキュメントをお読みください。あるいは、このデータ収集をオプトアウトする方法については [こちら](https://support.mozilla.org/kb/send-performance-data-improve-firefox) をご覧ください。
+[デスクトップ](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html)、または [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) 用のパフォーマンス情報の送信に関するドキュメントをお読みください。あるいは、このデータ収集をオプトアウトする方法については [こちら](https://support.mozilla.org/kb/send-performance-data-improve-firefox) をご覧ください。
 {: #telemetry }
 
 ### 既定の検索プロバイダーを設定する {: #defaultsearch }

--- a/firefox_privacy_notice/nl.md
+++ b/firefox_privacy_notice/nl.md
@@ -17,7 +17,7 @@ In deze Privacykennisgeving leggen we uit welke gegevens Firefox deelt en wijzen
 
 * __Technische gegevens__: Firefox verzendt gegevens over uw Firefox-versie en taal, het besturingssysteem van uw apparaat en uw hardwareconfiguratie, geheugen, basisinformatie over crashes en fouten en over resultaten van geautomatiseerde processen, zoals SafeBrowsing en activering. Wanneer Firefox ons gegevens stuurt, wordt uw IP-adres tijdelijk verzameld als onderdeel van onze serverlogboeken.
 
-Lees de telemetriedocumentatie voor [desktops](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html) [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) of [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) of lees hoe u zich kunt [uitschrijven](https://support.mozilla.org/kb/send-performance-data-improve-firefox) van het verzamelen van deze gegevens.
+Lees de telemetriedocumentatie voor [desktops](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html) [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) of [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) of lees hoe u zich kunt [uitschrijven](https://support.mozilla.org/kb/send-performance-data-improve-firefox) van het verzamelen van deze gegevens.
 {: #telemetry }
 
 ### Een standaardzoekprovider instellen {: #defaultsearch }

--- a/firefox_privacy_notice/pt-BR.md
+++ b/firefox_privacy_notice/pt-BR.md
@@ -17,7 +17,7 @@ Nesta nota sobre privacidade, explicamos quais dados o Firefox compartilha e com
 
 * __Dados técnicos__: O Firefox nos envia dados sobre a versão e idioma instalado, configuração do sistema operacional e do hardware do dispositivo, memória, informações básicas sobre travamentos e erros, resultado de processos automáticos, como atualizações, navegação segura e ativação. Quando o Firefox nos envia dados, seu endereço IP é temporariamente coletado como parte dos nossos registros de servidor.
 
-Leia a documentação de telemetria para [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) ou [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) ou saiba como [cancelar](https://support.mozilla.org/kb/send-performance-data-improve-firefox) essa coleta de dados.
+Leia a documentação de telemetria para [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) ou [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) ou saiba como [cancelar](https://support.mozilla.org/kb/send-performance-data-improve-firefox) essa coleta de dados.
 {: #telemetry }
 
 ### Definir um mecanismo de pesquisa padrão {: #defaultsearch }

--- a/firefox_privacy_notice/ru.md
+++ b/firefox_privacy_notice/ru.md
@@ -17,7 +17,7 @@
 
 * __Технические данные__: Firefox отправляет нам данные о версии и языке браузера, операционной системе устройства и конфигурации оборудования, объеме памяти, сбоях и ошибках, результатах автоматизированных процессов, таких как обновление, безопасный браузинг или активация.  Когда Firefox отправляет нам данные, временно передается и ваш IP-адрес (как элемент журналов нашего сервера).  
 
-Ознакомьтесь с документацией о телеметрии для [ПК](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html)/[Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html)/[iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) или узнайте, как [отказаться](https://support.mozilla.org/kb/send-performance-data-improve-firefox) от сбора этих данных.
+Ознакомьтесь с документацией о телеметрии для [ПК](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html)/[Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html)/[iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) или узнайте, как [отказаться](https://support.mozilla.org/kb/send-performance-data-improve-firefox) от сбора этих данных.
 {: #telemetry }
 
 ### Установка поисковой системы по умолчанию {: #defaultsearch }

--- a/firefox_privacy_notice/tr.md
+++ b/firefox_privacy_notice/tr.md
@@ -17,7 +17,7 @@ Bu Gizlilik Bildirimi’nde Firefox’un hangi bilgileri paylaştığını açı
 
 * __Teknik veriler__: Firefox, bize Firefox sürümü ve dili, cihaz işletim sistemi ve donanım yapılandırması, bellek, arızalar ve hatalar hakkında temel bilgiler, güncellemeler, güvenli gezinti ve aktivasyon hakkında veriler gönderir. Firefox bize veri gönderdiğinde, IP adresiniz sunucu günlüklerimiz için geçici olarak toplanır.
 
-[Masaüstü](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) ya da [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) için telemetre belgelerini okuyun ya da bu veri toplamadan nasıl [vazgeçeceğiniz](https://support.mozilla.org/kb/send-performance-data-improve-firefox) öğrenin.
+[Masaüstü](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) ya da [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) için telemetre belgelerini okuyun ya da bu veri toplamadan nasıl [vazgeçeceğiniz](https://support.mozilla.org/kb/send-performance-data-improve-firefox) öğrenin.
 {: #telemetry }
 
 ### Varsayılan bir arama sağlayıcı belirlemek {: #defaultsearch }

--- a/firefox_privacy_notice/zh-CN.md
+++ b/firefox_privacy_notice/zh-CN.md
@@ -17,7 +17,7 @@
 
 * __技术数据__：Firefox 会发送以下相关信息给我们：您 Firefox 的版本和语言；设备操作系统和硬件配置；内存、有关崩溃和错误的基本信息；诸如更新、安全浏览和激活等自动化流程的结果。当 Firefox 向我们发送数据时，会临时收集您的 IP 地址作为我们服务器日志的一部分。
 
-阅读针对[桌面](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) 或 [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) 的遥测技术文档，或者了解如何[选择退出](https://support.mozilla.org/kb/send-performance-data-improve-firefox)该数据收集功能。
+阅读针对[桌面](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) 或 [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry) 的遥测技术文档，或者了解如何[选择退出](https://support.mozilla.org/kb/send-performance-data-improve-firefox)该数据收集功能。
 {: #telemetry }
 
 ### 设置默认的搜索引擎 {: #defaultsearch }

--- a/firefox_privacy_notice/zh-TW.md
+++ b/firefox_privacy_notice/zh-TW.md
@@ -17,7 +17,7 @@
 
 * __技術資料__：Firefox 會傳送您的 Firefox 版本及語言、裝置作業系統及硬體配置、發生錯誤時的記憶體及基本資訊、更新、安全瀏覽、啟用等自動化程序執行的結果等資料給我們。Firefox 將資料傳送給我們的時候，我們也會暫時收集您的 IP 地址，列在我們伺服器的紀錄內。
 
-請閱讀 Telemetry 功能的說明文件：[桌機版](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/docs/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/docs/fennec/index.html) 或 [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry)，或者瞭解如何在您的裝置[關閉](https://support.mozilla.org/kb/send-performance-data-improve-firefox)此類資料收集活動。
+請閱讀 Telemetry 功能的說明文件：[桌機版](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html)、[Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/index.html) 或 [iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Telemetry)，或者瞭解如何在您的裝置[關閉](https://support.mozilla.org/kb/send-performance-data-improve-firefox)此類資料收集活動。
 {: #telemetry }
 
 ### 設定預設搜尋提供商 {: #defaultsearch }


### PR DESCRIPTION
It appears that the URL structure there changed.