### PR TITLE
Fix formatting for ScreenshotGo Privacy Notice

### DIFF
--- a/firefox_screenshotgo_privacy_notice/en-US.md
+++ b/firefox_screenshotgo_privacy_notice/en-US.md
@@ -3,7 +3,9 @@
 Version 1.0, effective September 28, 2018 
 {: datetime="2018-09-18" }
 
-The [Mozilla Privacy Policy](https://www.mozilla.org/privacy) describes how we handle information that we receive from you.  Things you should know:
+The [Mozilla Privacy Policy](https://www.mozilla.org/privacy) describes how we handle information that we receive from you.
+
+## Things you should know
 
 * **Screenshots:** Screenshots remain locally on your device. If you grant permission, Firefox ScreenshotGo will access them to be organized. Mozilla receives the average number of screenshots used by Firefox ScreenshotGo, including in default or new collections.
 

--- a/firefox_screenshotgo_privacy_notice/id.md
+++ b/firefox_screenshotgo_privacy_notice/id.md
@@ -3,7 +3,9 @@
 Versi 1.0, berlaku 28 September 2018 
 {: datetime="2018-09-18" }
 
-[Kebijakan Privasi Mozilla](https://www.mozilla.org/privacy) menjelaskan cara kami menangani informasi yang kami terima dari Anda. Berikut adalah hal-hal yang perlu Anda ketahui:
+[Kebijakan Privasi Mozilla](https://www.mozilla.org/privacy) menjelaskan cara kami menangani informasi yang kami terima dari Anda.
+
+## Berikut adalah hal-hal yang perlu Anda ketahui
 
 * **Tangkapan layar:** Tangkapan layar tetap disimpan di perangkat Anda. Jika Anda memberikan izin, Firefox ScreenshotGo akan mengaksesnya untuk dikelola. Mozilla menerima informasi jumlah rata-rata tangkapan layar yang digunakan oleh Firefox ScreenshotGo, termasuk yang berada dalam koleksi default atau baru.
 


### PR DESCRIPTION
This is required for https://github.com/mozilla/bedrock/issues/6229 as bedrock does some section formatting that requires a header before a list.