### PR TITLE
Update nl.md

### DIFF
--- a/firefox_privacy_notice/nl.md
+++ b/firefox_privacy_notice/nl.md
@@ -1,4 +1,4 @@
-## <span class="privacy-header-firefox">Firefox</span> <span class="privacy-header-policy">Privacykennisgeving</span>
+## <span class="privacy-header-firefox">Firefox</span>-<span class="privacy-header-policy">privacyverklaring</span>
 
 *Van kracht vanaf 28 september 2017*
 {: datetime="2017-09-28" }
@@ -7,13 +7,13 @@
 
 Dat is de reden waarom we Firefox maken, en al onze producten, zodat u meer controle hebt over de informatie die u online deelt en de informatie die u met ons deelt. We streven ernaar om alleen te verzamelen wat we nodig hebben om Firefox voor iedereen te verbeteren.
 
-In deze Privacykennisgeving leggen we uit welke gegevens Firefox deelt en wijzen u op instellingen om nog minder te delen. We houden ons daarnaast aan de procedures die zijn beschreven in het [privacybeleid](https://www.mozilla.org/privacy/) van Mozilla voor wat betreft hoe we informatie die we verzamelen via Firefox, ontvangen, hanteren en delen.
+In deze Privacyverklaring leggen we uit welke gegevens Firefox deelt en wijzen we u op instellingen om nog minder te delen. Daarnaast houden we ons aan de procedures die in het [privacybeleid](https://www.mozilla.org/privacy/) van Mozilla worden beschreven voor wat betreft hoe we informatie die we via Firefox verzamelen ontvangen, hanteren en delen.
 
 ## Firefox deelt standaard gegevens voor:
 
 ### Het verbeteren van de prestaties en stabiliteit voor alle gebruikers {: #health-report }
 
-* __Interactiegegevens__: Firefox verzendt gegevens naar ons over uw interactie met Firefox (zoals het aantal open tabbladen en vensters, het aantal bezochte webpagina's en het type geïnstalleerde Firefox-add-ons en de sessieduur) en Firefox-functies die door Mozilla of onze partners worden aangeboden (zoals uw interactie met Firefox-zoekfuncties en zoekpartnerverwijzingen).
+* __Interactiegegevens__: Firefox verzendt gegevens naar ons over uw interactie met Firefox (zoals het aantal open tabbladen en vensters, het aantal bezochte webpagina’s en het type geïnstalleerde Firefox-add-ons en de sessieduur) en Firefox-functies die door Mozilla of onze partners worden aangeboden (zoals uw interactie met Firefox-zoekfuncties en zoekpartnerverwijzingen).
 
 * __Technische gegevens__: Firefox verzendt gegevens over uw Firefox-versie en taal, het besturingssysteem van uw apparaat en uw hardwareconfiguratie, geheugen, basisinformatie over crashes en fouten en over resultaten van geautomatiseerde processen, zoals SafeBrowsing en activering. Wanneer Firefox ons gegevens stuurt, wordt uw IP-adres tijdelijk verzameld als onderdeel van onze serverlogboeken.
 
@@ -22,7 +22,7 @@ Lees de telemetriedocumentatie voor [desktops](https://firefox-source-docs.mozil
 
 ### Een standaardzoekprovider instellen {: #defaultsearch }
 
-* __Locatiegegevens__:  Wanneer u Firefox voor het eerst gebruikt, wordt uw IP-adres op basis van uw land gebruikt voor het instellen van uw standaardzoekprovider. [Meer informatie](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
+* __Locatiegegevens__: wanneer u Firefox voor het eerst gebruikt, wordt uw IP-adres op basis van uw land gebruikt voor het instellen van uw standaardzoekprovider. [Meer informatie](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
 
 ### Voorgestelde relevante inhoud 
 
@@ -32,50 +32,50 @@ Firefox geeft inhoud weer, zoals Snippets (berichten van Mozilla), Top Sites (do
 
 * __Technische en interactiegegevens__: Firefox verzendt gegevens naar ons, zoals de positie, grootte en plaatsing van inhoud die we voorstellen, evenals basisgegevens over uw interactie met inhoud die door Firefox wordt voorgesteld. Dit omvat het aantal keren dat voorgestelde inhoud wordt weergegeven of dat daarop wordt geklikt.
 
-* __Webpaginagegevens voor Snippets__: Wanneer u ervoor kies om op een Snippet-koppeling te klikken, ontvangen we mogelijk gegevens over de koppeling die u hebt gevolgd. Deze informatie is niet gekoppeld aan enige andere informatie over u. [Meer informatie](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
+* __Webpaginagegevens voor Snippets__: wanneer u ervoor kies om op een Snippet-koppeling te klikken, ontvangen we mogelijk gegevens over de koppeling die u hebt gevolgd. Deze informatie is niet gekoppeld aan enige andere informatie over u. [Meer informatie](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html).
 {: #snippets }
 
-* __Webpaginagegevens voor Pocket-aanbevelingen__: We stellen inhoud aan u voor op basis van uw browsergeschiedenis. Het proces van het beslissen van welke verhalen moeten worden weergegeven, vindt plaats in uw lokale exemplaar van Firefox, en noch Mozilla, noch Pocket ontvangt een kopie van uw browsergeschiedenis. We ontvangen wel gegevens over de aanbevelingen die worden weergegeven en waarop u klikt. [Meer informatie](https://help.getpocket.com/article/1142-firefox-new-tab-recommendations).
+* __Webpaginagegevens voor Pocket-aanbevelingen__: we stellen inhoud aan u voor op basis van uw browsergeschiedenis. Het proces van het beslissen van welke verhalen moeten worden weergegeven vindt plaats in uw lokale exemplaar van Firefox, en noch Mozilla, noch Pocket ontvangt een kopie van uw browsergeschiedenis. We ontvangen wel gegevens over de aanbevelingen die worden weergegeven en waarop u klikt. [Meer informatie](https://help.getpocket.com/article/1142-firefox-new-tab-recommendations).
 
 ### Beveiliging verbeteren voor alle gebruikers {: #security }
 
-* __Technische gegevens voor updates__: Desktopversies van Firefox controleren periodiek op browserupdates door verbinding te maken met Mozilla-servers. Gegevens over uw Firefox-versie, taal en het besturingssysteem van uw apparaat worden gebruikt om de juiste updates toe te passen. Mobiele versies van Firefox kunnen verbinding maken met een andere service als u deze hebt gebruikt voor het downloaden en installeren van Firefox. [Meer informatie](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
+* __Technische gegevens voor updates__: desktopversies van Firefox controleren periodiek op browserupdates door verbinding te maken met Mozilla-servers. Gegevens over uw Firefox-versie, taal en het besturingssysteem van uw apparaat worden gebruikt om de juiste updates toe te passen. Mobiele versies van Firefox kunnen verbinding maken met een andere service als u deze hebt gebruikt voor het downloaden en installeren van Firefox. [Meer informatie](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_automatische-update-is-bezig-met-controleren).
 {: #auto-updates }
 
 * __Technische gegevens voor de lijst met geblokkeerde add-ons__: Firefox voor desktops en Android maken periodiek verbinding met Mozilla om u en anderen te beschermen tegen schadelijke add-ons. Gegevens over uw Firefox-versie en taal, het besturingssysteem van uw apparaat en de lijst met geïnstalleerde add-ons zijn nodig om de lijst met geblokkeerde add-ons toe te passen en bij be werken. [Meer informatie](https://support.mozilla.org/kb/how-stop-firefox-making-automatic-connections). 
 
-* __Webpagina- en technische gegevens naar de SafeBrowsing-service van Google__: Firefox verzendt basisinformatie over niet-herkende downloads aan de SafeBrowsing-service van Google, waaronder de bestandsnaam en de URL vanaf welke er is gedownload om u te beschermen tegen schadelijke downloads.
+* __Technische en webpaginagegevens naar de SafeBrowsing-service van Google__: Firefox verzendt basisinformatie over niet-herkende downloads naar de SafeBrowsing-service van Google, waaronder de bestandsnaam en de URL vanaf welke er is gedownload om u te beschermen tegen schadelijke downloads.
 
     Raadpleeg [meer informatie](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) of lees het [privacybeleid van Google](https://www.google.com/policies/privacy/). Als u zich uitschrijft, voorkomt u daarmee dat Firefox u kan waarschuwen voor potentieel niet-legitieme of schadelijke websites of gedownloade bestanden.
 
-* __Webpagina- en technische gegevens naar certificeringsinstanties__: Wanneer u een beveiligde website bezoekt (doorgaans te herkennen aan een URL die begint met HTTPS), valideert Firefox het [certificaat](https://support.mozilla.org/kb/secure-website-certificate) van de website. Dit kan gepaard gaan met het door Firefox verzenden van bepaalde informatie over de website aan de certificeringsinstantie die wordt aangeduid door de desbetreffende website.
+* __Technische en webpaginagegevens naar certificaatautoriteiten__: wanneer u een beveiligde website bezoekt (doorgaans te herkennen aan een URL die met HTTPS begint), valideert Firefox het [certificaat](https://support.mozilla.org/kb/secure-website-certificate) van de website. Dit kan gepaard gaan met het door Firefox verzenden van bepaalde informatie over de website naar de certificaatautoriteit die door de desbetreffende website wordt aangeduid.
 
-    Als u zich uitschrijft, kan dat het risico verhogen dat uw persoonlijke informatie wordt onderschept. [Meer informatie](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab).
+    Als u zich uitschrijft, kan dat het risico op het onderscheppen van uw persoonlijke gegevens verhogen. [Meer informatie](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_tabblad-certificaten).
 
 ### Crashrapporten {: #crash-reporter }
-Standaard wordt u in desktopversies van Firefox gevraagd om met Mozilla een rapport te delen dat gedetailleerde informatie bevat over Mozilla, maar u hebt altijd de keuze om dit te weigeren.
+Standaard wordt u in desktopversies van Firefox gevraagd om een rapport met meer gedetailleerde informatie over crashes met Mozilla te delen, maar u hebt altijd de keuze om dit te weigeren.
 
-* __Gevoelige gegevens__:  Crashrapporten omvatten een dumpbestand van de geheugeninhoud van Firefox op het moment van de crash. Dit bestand kan gegevens bevatten op basis waarvan u of voor u mogelijk gevoelige gegevens kunnen worden geïdentificeerd.
+* __Gevoelige gegevens__: crashrapporten omvatten een dumpbestand van de geheugeninhoud van Firefox op het moment van de crash. Dit bestand kan gegevens bevatten op basis waarvan u of voor u mogelijk gevoelige gegevens kunnen worden geïdentificeerd.
 
-* __Webpaginagegevens__:  Crashrapporten bevatten de actieve URL op het moment van de crash.
+* __Webpaginagegevens__: crashrapporten bevatten de actieve URL op het moment van de crash.
 
-* __Technische gegevens__:  Crashrapporten bevatten gegevens over waarom Firefox is gecrasht en de staat van het apparaatgeheugen en de uitvoering tijdens de crash.
+* __Technische gegevens__: crashrapporten bevatten gegevens over waarom Firefox is gecrasht en de staat van het apparaatgeheugen en de uitvoering tijdens de crash.
 
 De volledige documentatie kunt u [hier](https://firefox-source-docs.mozilla.org/toolkit/crashreporter/crashreporter/index.html) lezen.
 
 ### Ondersteuning en meten van onze marketing
 
-* __Campagne- en verwijzingsgegevens__: Deze gegevens helpen Mozilla de doeltreffendheid van onze marketingcampagnes te doorgronden.
+* __Campagne- en verwijzingsgegevens__: deze gegevens helpen Mozilla de doeltreffendheid van onze marketingcampagnes te doorgronden.
 {: #referraltracking }
 
-    _Op desktop_: Firefox verzendt standaard HTTP-gegevens aan Mozilla die mogelijk zijn opgenomen in het installatieprogramma van Firefox. Deze gegevens stellen ons in staat te bepalen welk websitedomein of welke reclamecampagne (indien aanwezig) u naar de onze downloadpagina heeft verwezen. Lees de [documentatie](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) of [schrijf u uit](https://support.mozilla.org/kb/desktop-privacy) voordat u de installatie uitvoert.
+    _Op desktop_: Firefox verzendt standaard HTTP-gegevens naar Mozilla die mogelijk in het installatieprogramma van Firefox zijn opgenomen. Met deze gegevens kunnen we bepalen welk websitedomein of welke reclamecampagne (indien aanwezig) u naar de onze downloadpagina heeft verwezen. Lees de [documentatie](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) of [schrijf u uit](https://support.mozilla.org/kb/desktop-privacy) voordat u de installatie uitvoert.
 
-    _Bij iOS en Android_: Firefox verzendt standaard mobiele campagnegegevens aan Adjust, onze leverancier voor analysegegevens. Adjust heeft een eigen [privacybeleid](https://www.adjust.com/privacy_policy/). Mobiele campagnegegevens bestaan uit een Google-reclame-id, uw IP-adres, tijdstempel, land, taal/landinstellingen, besturingssysteem en app-versie. Lees de [documentatie](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
+    _Bij iOS en Android_: Firefox verzendt standaard mobiele campagnegegevens naar Adjust, onze leverancier voor analysegegevens. Adjust heeft een eigen [privacybeleid](https://www.adjust.com/privacy_policy/). Mobiele campagnegegevens bestaan uit een Google-reclame-id, uw IP-adres, tijdstempel, land, taal/landinstellingen, besturingssysteem en app-versie. Lees de [documentatie](https://firefox-source-docs.mozilla.org/mobile/android/fennec/adjust.html).
 {: #thirdparty }
 
 * __Technische en interactiegegevens__: 
 
-    _Bij iOS en Android_: Firefox verzendt standaard gegevens over welke functies u in Firefox gebruikt naar Leanplum. Leanplum levert marketing voor mobiele apparaten en heeft een eigen [privacybeleid](https://www.leanplum.com/privacy/). Met deze gegevens kunnen wij verschillende functies en ervaringen testen en aangepaste berichten en aanbevelingen aanbieden om de ervaring met Firefox te verbeteren.
+    _Bij iOS en Android_: Firefox verzendt standaard gegevens over welke functies u in Firefox gebruikt naar Leanplum. Leanplum levert marketing voor mobiele apparaten en heeft een eigen [privacybeleid](https://www.leanplum.com/privacy/). Met deze gegevens kunnen we verschillende functies en ervaringen testen en aangepaste berichten en aanbevelingen aanbieden om de ervaring met Firefox te verbeteren.
 
     Raadpleeg de documentatie van [iOS](https://github.com/mozilla-mobile/firefox-ios/blob/master/MMA.md) of [Android](https://firefox-source-docs.mozilla.org/mobile/android/fennec/mma.html) of lees hoe u deze [functie uitschakelt](https://support.mozilla.org/kb/send-anonymous-usage-data-firefox-mobile-devices).
 
@@ -85,66 +85,66 @@ De volledige documentatie kunt u [hier](https://firefox-source-docs.mozilla.org/
 
 ### Zoeken:
 
-U kunt op verschillende plaatsen in Firefox rechtstreeks zoekopdrachten uitvoeren, waaronder op de balk Awesome, de zoekbalk of op een nieuw tabblad.  _Uw zoekquery's worden niet door Mozilla ontvangen._ Querygegevens worden naar uw zoekprovider verzonden. Deze heeft een eigen privacybeleid.
+Op verschillende plaatsen in Firefox kunt u rechtstreeks zoekopdrachten uitvoeren, waaronder op de adresbalk, de zoekbalk of op een nieuw tabblad. _Uw zoekquery’s worden niet door Mozilla ontvangen._ Querygegevens worden naar uw zoekprovider verzonden. Deze heeft een eigen privacybeleid.
 
-* __Zoeksuggesties__: Firefox verzendt standaard zoekquery's naar uw zoekprovider, zodat er veelgebruikte zinnen kunnen worden weergegeven waarnaar anderen hebben gezocht en uw zoekervaring kan worden verbeterd. Deze gegevens worden niet naar uw geselecteerde zoekprovider verzonden als deze geen zoeksuggesties ondersteunt.
+* __Zoeksuggesties__: Firefox verzendt standaard zoekquery’s naar uw zoekprovider, zodat veelgebruikte woordgroepen waarnaar anderen hebben gezocht kunnen worden weergegeven en uw zoekervaring kan worden verbeterd. Deze gegevens worden niet naar uw geselecteerde zoekprovider verzonden als deze geen zoeksuggesties ondersteunt.
 {: #searchsuggestions } 
 
     Lees [meer informatie](https://support.mozilla.org/kb/use-popular-search-suggestions-firefox-search-bar), waaronder informatie over hoe u deze functie kunt uitschakelen.
 
 ### Firefox-accounts
 
-* __Firefox-accountgegevens__: Mozilla ontvangt uw e-mailadres en een hash van uw wachtwoord wanneer u een Firefox-account maakt. U kunt ervoor kiezen om een weergavenaam of profielafbeelding op te nemen. Uw e-mailadres wordt verzonden naar onze leverancier voor e-mail, SalesForce Marketing Cloud. SalesForce Marketing Cloud heeft een eigen [privacybeleid](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Als u uw Firefox-account gebruikt om u aan te melden bij andere websites of services (zoals AMO of Pocket), ontvangen we de tijdstempel van uw aanmelding bij die services. 
+* __Firefox-accountgegevens__: Mozilla ontvangt uw e-mailadres en een hash van uw wachtwoord wanneer u een Firefox-account aanmaakt. U kunt ervoor kiezen om een weergavenaam of profielafbeelding bj te voegen. Uw e-mailadres wordt verzonden naar onze leverancier voor e-mail, SalesForce Marketing Cloud. SalesForce Marketing Cloud heeft een eigen [privacybeleid](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/). Als u uw Firefox-account gebruikt om u bij andere websites of services (zoals AMO of Pocket) aan te melden, ontvangen we de tijdstempel van uw aanmelding bij die services. 
 
-* __Locatiegegevens__: Om beveiligingsredenen slaan we de IP-adressen op die u gebruikt om toegang te krijgen tot uw Firefox-account, zodat uw plaats en land bij benadering kunnen worden bepaald. We gebruiken deze gegevens om u e-mailmeldingen te sturen als we verdachte activiteiten detecteren, zoals accountaanmeldingen vanaf andere locaties.
+* __Locatiegegevens__: om beveiligingsredenen slaan we de IP-adressen op die u gebruikt om toegang te krijgen tot uw Firefox-account, zodat uw plaats en land bij benadering kunnen worden bepaald. We gebruiken deze gegevens om u e-mailmeldingen te sturen als we verdachte activiteiten detecteren, zoals accountaanmeldingen vanaf andere locaties.
 
-* __Interactiegegevens__: We ontvangen gegevens over zaken zoals bezoeken aan en de interactie met de website voor Firefox-accounts en menuvoorkeuren en interactie op het vlak van onboarding, e-mail en SMS-berichten. Lees [meer informatie](https://www.mozilla.org/privacy/websites/) over de gegevensprocedures van Mozilla voor websites en e-mail.
+* __Interactiegegevens__: we ontvangen gegevens over zaken zoals bezoeken aan en de interactie met de Firefox Accounts-website en menuvoorkeuren, en interactie op het vlak van onboarding, e-mail en sms-berichten. Lees [meer informatie](https://www.mozilla.org/privacy/websites/) over de gegevensprocedures van Mozilla voor websites en e-mail.
 
-* __Technische gegevens__: Voor het weergeven van welke apparaten worden gesynchroniseerd met uw Firefox-account en voor het leveren van functionaliteit slaan we informatie op, zoals het besturingssysteem van uw apparaat, browser en versie, tijdstempel en landinstelling. We slaan dezelfde informatie op voor apparaten die met uw account zijn verbonden.
+* __Technische gegevens__: voor het weergeven van welke apparaten worden gesynchroniseerd met uw Firefox-account en voor het leveren van functionaliteit slaan we informatie op, zoals het besturingssysteem van uw apparaat, browser en versie, tijdstempel en landinstelling. We slaan dezelfde informatie op voor apparaten die met uw account zijn verbonden.
 
 Raadpleeg de [volledige documentatie](https://github.com/mozilla/fxa-auth-server/blob/master/docs/metrics-events.md) of lees [meer informatie](https://support.mozilla.org/kb/access-mozilla-services-firefox-accounts), waaronder informatie over [hoe u uw account kunt verwijderen](https://support.mozilla.org/kb/how-do-i-delete-my-firefox-account).
 
-### Synchronisatie {: #sync }
+### Sync {: #sync }
 
-* __Gesynchroniseerde gegevens__: Als u de synchronisatie-optie instelt, ontvangt Mozilla de informatie die u via apparaten synchroniseert in versleutelde vorm. Deze informatie heeft mogelijk betrekking op Firefox-tabbladen, add-ons, wachtwoorden, betalingsinformatie die automatisch wordt ingevuld, bladwijzers, uw geschiedenis en voorkeuren. Als u uw Firefox-account verwijdert, wordt ook de verwante synchronisatie-inhoud verwijderd. U kunt daarnaast de [documentatie](https://moz-services-docs.readthedocs.io/en/latest/sync/) lezen.
+* __Gesynchroniseerde gegevens__: als u de synchronisatie-optie instelt, ontvangt Mozilla de informatie die u via apparaten synchroniseert in versleutelde vorm. Deze informatie heeft mogelijk betrekking op Firefox-tabbladen, add-ons, wachtwoorden, betalingsinformatie die automatisch wordt ingevuld, bladwijzers, uw geschiedenis en voorkeuren. Als u uw Firefox-account verwijdert, wordt ook de verwante synchronisatie-inhoud verwijderd. U kunt daarnaast de [documentatie](https://moz-services-docs.readthedocs.io/en/latest/sync/) lezen.
   
-* __Technische en interactiegegevens__: Als u synchronisatie heeft ingeschakeld, verzendt Firefox periodiek basisinformatie met telemetrie over uw recentste poging om uw gegevens te synchroniseren, zoals wanneer de synchronisatie is uitgevoerd of mislukt en welk type apparaat probeert te synchroniseren. U kunt daarnaast de [documentatie](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html) lezen.
+* __Technische en interactiegegevens__: als u synchronisatie hebt ingeschakeld, verzendt Firefox periodiek basisinformatie met telemetrie over uw meest recente poging om uw gegevens te synchroniseren, zoals wanneer de synchronisatie is uitgevoerd of mislukt en welk type apparaat probeert te synchroniseren. U kunt daarnaast de [documentatie](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html) lezen.
 
 Lees [meer informatie](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), waaronder informatie over hoe u synchronisatie kunt inschakelen of uitschakelen.
 
 ### Locatie {: #location-services }
 
-* __Locatiegegevens naar de geolocatieservice van Google__: Firefox vraagt u altijd eerst of dit mag voordat uw locatie wordt bepaald of gedeeld met een aanvragende website (bijvoorbeeld als een website voor kaarten uw locatie nodig heeft voor een routebeschrijving). Voor het vaststellen van de locatie gebruikt Firefox mogelijk de geolocatiefuncties van uw besturingssysteem, Wi-Fi-netwerken, gsm-torens of IP-adressen. Deze gegevens kunnen worden verzonden naar de geolocatieservice van Google. Google heeft een eigen [privacybeleid](https://www.google.com/privacy/lsf.html).
+* __Locatiegegevens naar de geolocatieservice van Google__: Firefox vraagt u altijd eerst of dit mag voordat uw locatie wordt bepaald of met een aanvragende website wordt gedeeld (bijvoorbeeld als een website voor kaarten uw locatie nodig heeft voor een routebeschrijving). Voor het vaststellen van de locatie gebruikt Firefox mogelijk de geolocatiefuncties van uw besturingssysteem, wifi-netwerken, gsm-zendmasten of IP-adressen. Deze gegevens kunnen naar de geolocatieservice van Google worden verzonden. Google heeft een eigen [privacybeleid](https://www.google.com/privacy/lsf.html).
 
 [Meer informatie](https://www.mozilla.org/firefox/geolocation/).
 
-### Firefox-schermopnamen{: #screenshots }
+### Firefox Screenshots {: #screenshots }
 
-* __Uploads van schermopnamen__: Schermopnamen die u uploadt, worden naar Mozilla verzonden en gedurende een aangegeven beperkte periode bewaard. U kunt deze periode wijzigen. We kunnen schermopnamen die u hebt geüpload, mogelijk openen wanneer dat redelijkerwijs noodzakelijk is voor de werking van de service. U kunt schermopnamen die u hebt geüpload op elk gewenst moment verwijderen.
+* __Uploads van schermafbeeldingen__: schermafbeeldingen die u uploadt, worden naar Mozilla verzonden en gedurende een aangegeven beperkte periode bewaard. U kunt deze periode wijzigen. Mogelijk kunnen we schermafbeeldingen die u hebt geüpload openen wanneer dat redelijkerwijs noodzakelijk is voor de werking van de service. Schermafbeeldingen die u hebt geüpload, kunt op elk gewenst moment verwijderen.
 
-* __Interactiegegevens__: We ontvangen gegevens, zoals informatie over bezoeken aan de website voor Firefox-schermopnamen, hoe vaak schermopnamen die zijn geüpload, worden geopend en door u gedeeld met anderen en uw interactie met knoppen, tegels en muisbewegingen met betrekking tot het vastleggen van schermopnamen.
+* __Interactiegegevens__: we ontvangen gegevens, zoals informatie over bezoeken aan de Firefox Screenshots-website, hoe vaak schermafbeeldingen die zijn geüpload worden geopend en door u met anderen worden gedeeld, en uw interactie met knoppen, tegels en muisbewegingen met betrekking tot het vastleggen van schermafbeeldingen.
 
-    In onze [privacykennisgeving voor websites](https://www.mozilla.org/privacy/websites/) worden de typen gegevens beschreven die we daarnaast kunnen verzamelen tijdens bezoeken aan de website voor Firefox-schermopnamen.
+    Voor bezoeken aan de Firefox Screenshots-website beschrijft onze [privacyverklaring voor websites](https://www.mozilla.org/privacy/websites/) de typen gegevens die we daarnaast kunnen verzamelen.
 
-* __Technische gegevens__: We ontvangen gegevens, zoals informatie over de gemiddelde grootte en het aantal schermopnamen dat is geüpload, uw Firefox-browserversie, het besturingssysteem van uw apparaat en fouten. Het IP-adres dat wordt gebruikt voor de toegang tot de website voor Firefox-schermopnamen, wordt tijdelijk verzameld als onderdeel van ons standaardserverlogboek. 
+* __Technische gegevens__: we ontvangen gegevens, zoals informatie over de gemiddelde grootte en het aantal schermafbeeldingen dat is geüpload, uw Firefox-browserversie, het besturingssysteem van uw apparaat en fouten. Het IP-adres dat voor de toegang tot de Firefox screenshots-website wordt gebruikt, wordt tijdelijk verzameld als onderdeel van ons standaardserverlogboek. 
 
 Raadpleeg de [volledige documentatie](https://github.com/mozilla-services/screenshots/blob/master/docs/METRICS.md) of lees [meer informatie](https://wiki.mozilla.org/Firefox/Screenshots/FAQs).
 
-### Kennisgevingen van websites{: #push-notifications }
+### Notificaties van websites {: #push-notifications }
 
-* __Verbindingsgegevens__: Als u een website toestaat om kennisgevingen te verzenden, maakt Firefox verbinding met Mozilla en wordt uw IP-adres gebruikt om het bericht door te geven. Mozilla heeft geen toegang tot de inhoud van berichten. 
+* __Verbindingsgegevens__: als u een website toestaat om notificaties te verzenden, maakt Firefox verbinding met Mozilla en wordt uw IP-adres gebruikt om het bericht door te geven. Mozilla heeft geen toegang tot de inhoud van berichten. 
 
-* __Interactiegegevens__: We ontvangen samengevoegde gegevens, zoals het aantal Firefox-abonnementen en opzeggingen van abonnementen op kennisgevingen van websites, het aantal verzonden berichten, de tijdstempel en afzenders (welke mogelijk specifieke websiteproviders kunnen bevatten).
+* __Interactiegegevens__: we ontvangen samengevoegde gegevens, zoals het aantal Firefox-abonnementen en opzeggingen van abonnementen op notificaties van websites, het aantal verzonden berichten, de tijdstempel en afzenders (die mogelijk specifieke websiteproviders kunnen bevatten).
 
-Raadpleeg de [volledige documentatie](https://mozilla-push-service.readthedocs.io/en/latest/) of lees [meer informatie](https://support.mozilla.org/kb/push-notifications-firefox), waaronder informatie over hoe u kennisgevingen van websites kunt intrekken.
+Raadpleeg de [volledige documentatie](https://mozilla-push-service.readthedocs.io/en/latest/) of lees [meer informatie](https://support.mozilla.org/kb/push-notifications-firefox), waaronder informatie over hoe u notificaties van websites kunt intrekken.
 
 ### Add-ons {: #addons }
 
 U kunt add-ons installeren vanaf addons.mozilla.org (AMO) of vanuit de optie voor add-onbeheer in Firefox. Deze is toegankelijk via de Firefox-menuknop op de werkbalk.
  
-* __Zoekquery's__: Zoekquery's via de functie voor add-onbeheer worden verzonden aan Mozilla, zodat u voorgestelde add-ons kunnen worden aangeboden.
+* __Zoekquery’s__: zoekquery’s via de functie voor add-onbeheer worden verzonden aan Mozilla, zodat u voorgestelde add-ons kunnen worden aangeboden.
 
-* __Interactiegegevens__:  We ontvangen samengevoegde gegevens over bezoeken aan de AMO-website en de functie voor add-onbeheer in Firefox, evenals over uw interactie met inhoud op deze pagina's. Lees over onze gegevensprocedures op de [Mozilla-websites](https://www.mozilla.org/privacy/websites/).
+* __Interactiegegevens__: we ontvangen samengevoegde gegevens over bezoeken aan de AMO-website en de functie voor add-onbeheer in Firefox, evenals over uw interactie met inhoud op deze pagina’s. Lees meer over onze gegevensprocedures op de [Mozilla-websites](https://www.mozilla.org/privacy/websites/).
 
 * __Technische gegevens voor updates__: Firefox maakt periodiek verbinding met Mozilla om updates voor add-ons te installeren. Uw geïnstalleerde add-ons, uw Firefox-versie, taal en het besturingssysteem van uw apparaat worden gebruikt om de juiste updates toe te passen.
 
@@ -152,7 +152,7 @@ U kunt add-ons installeren vanaf addons.mozilla.org (AMO) of vanuit de optie voo
 
 ### Voetnoot
 
-Deze privacykennisgeving is bestemd voor de recentste algemene releaseversie van Firefox die door Mozilla wordt gedistribueerd. Als u Firefox elders verkrijgt of een oudere versie uitvoert, heeft uw exemplaar van Firefox mogelijk andere privacykenmerken.
+Deze privacyverklaring is bestemd voor de meest recente algemene releaseversie van Firefox die door Mozilla wordt gedistribueerd. Als u Firefox elders verkrijgt of een oudere versie uitvoert, heeft uw exemplaar van Firefox mogelijk andere privacykenmerken.
 {: #pre-release }
 
-Pre-release-versies van Firefox van Mozilla (die worden gedistribueerd via kanalen, zoals Nightly, Beta, Developer Edition en TestFlight) zijn ontwikkelingsplatforms die regelmatig worden bijgewerkt met experimentele functies en onderzoeken. Naast het verzamelen van de gegevens die zijn beschreven in deze privacykennisgeving, kunnen deze versies standaard gegevens over bepaalde webactiviteiten en crashes naar Mozilla en, in sommige gevallen, naar onze partners verzenden. Het verzamelen of delen van deze gegevens geschiedt in overeenstemming met het [Firefox-beleid voor gegevensverzameling](https://wiki.mozilla.org/Firefox/Data_Collection). We zullen hierbij altijd transparant te werk gaan en u middelen bieden om deze functie te beheren.
+Pre-releaseversies van Firefox van Mozilla (die worden gedistribueerd via kanalen, zoals Nightly, Beta, Developer Edition en TestFlight) zijn ontwikkelplatformen die regelmatig worden bijgewerkt met experimentele functies en onderzoeken. Naast het verzamelen van de gegevens die in deze privacyverklaring worden beschreven, kunnen deze versies standaard gegevens over bepaalde webactiviteiten en crashes naar Mozilla verzenden, en in sommige gevallen naar onze partners. Het verzamelen of delen van deze gegevens geschiedt in overeenstemming met het [Firefox-beleid voor gegevensverzameling](https://wiki.mozilla.org/Firefox/Data_Collection). We zullen hierbij altijd transparant te werk gaan en u middelen bieden om deze functie te beheren.


### PR DESCRIPTION
Several link, grammar and terminology fixes.

A few links at the bottom don’t display correctly, some terminology (e.g. for Privacy Notice) doesn’t match what we use, and some word order changes and grammar nits were applied.

(Side note: if possible, please ask the agency to make sure they check any locale’s terminology and style for any next translation delivered.)