### PR TITLE
Firefox Rocket and Rocket to Firefox Lite - zh-CN

### DIFF
--- a/rocket_privacy_notice/zh-CN.md
+++ b/rocket_privacy_notice/zh-CN.md
@@ -1,52 +1,51 @@
-## <span class="privacy-header-firefox-rocket">Firefox Rocket</span> <span class="privacy-header-policy">隐私声明</span>
+## <span class="privacy-header-firefox-lite">Firefox Lite</span> <span class="privacy-header-policy">隐私声明</span>
 
 2017年11月7日
 {: datetime="2017-11-07" }
 
 ## 在 Mozilla, 我们坚信隐私安全是健康互联网环境的基础。
 
-这正是我们为什么构建Firefox Rocket和我们所有产品的原因，为了用户能更好地控制在线分享的信息以及与我们分享的信息。我们尽量只收集改进Rocket所需要的信息。
+这正是我们为什么构建Firefox Lite和我们所有产品的原因，为了用户能更好地控制在线分享的信息以及与我们分享的信息。我们尽量只收集改进Firefox Lite所需要的信息。
  
-在本隐私声明中，我们解释了Rocket会共享哪些数据，并引导您使用可以尽量少共享数据的设置。对于如何接收、处理和共享从Rocket收集的信息，我们也会遵守Mozilla [隐私政策中所](https://www.mozilla.org/privacy/) 隐私政策中所述的做法。
+在本隐私声明中，我们解释了Firefox Lite会共享哪些数据，并引导您使用可以尽量少共享数据的设置。对于如何接收、处理和共享从Firefox Lite收集的信息，我们也会遵守Mozilla [隐私政策中所](https://www.mozilla.org/privacy/) 隐私政策中所述的做法。
 
-## 默认情况下，Firefox Rocket出于以下目的共享数据：
+## 默认情况下，Firefox Lite出于以下目的共享数据：
 
 ### 为任何地点的用户改进性能和稳定性
 
-* __交互数据__: Rocket会向我们发送有关您与Rocket互动的数据（访问的网页数量和会话长度），以及Mozilla或我们的合作伙伴提供的Rocket功能（例如借助Rocket搜索功能和搜索合作伙伴推荐实现的互动）。
+* __交互数据__: Firefox Lite会向我们发送有关您与Firefox Lite互动的数据（访问的网页数量和会话长度），以及Mozilla或我们的合作伙伴提供的Firefox Lite功能（例如借助Firefox Lite搜索功能和搜索合作伙伴推荐实现的互动）。
 
-* __技术数据__: Rocket会发送以下数据：您的Rocket版本和语言；设备操作系统和硬件配置；内存，关于崩溃和错误的基本信息；自动化过程（如更新）的结果，以及激活信息。当Rocket向我们发送数据时，您的IP地址将暂时作为服务器日志的一部分收集。  
+* __技术数据__: Firefox Lite会发送以下数据：您的Firefox Lite版本和语言；设备操作系统和硬件配置；内存，关于崩溃和错误的基本信息；自动化过程（如更新）的结果，以及激活信息。当Firefox Lite向我们发送数据时，您的IP地址将暂时作为服务器日志的一部分收集。  
 
-[在此](https://github.com/mozilla-tw/Rocket/wiki/Telemetry)阅读Rocket的详细文档或了解如何[退出](https://support.mozilla.org/kb/send-performance-data-improve-firefox)此数据收集。
+[在此](https://github.com/mozilla-tw/Firefox-Lite/wiki/Telemetry)阅读Firefox Lite的详细文档或了解如何[退出](https://support.mozilla.org/kb/send-performance-data-improve-firefox)此数据收集。
 {: #telemetry }
 
 ### 建议相关内容
 
-Rocket会显示内容，例如热门网站（由Mozilla为Rocket新用户推荐的网站）。
+Firefox Lite会显示内容，例如热门网站（由Mozilla为Firefox Lite新用户推荐的网站）。
 
-* __技术数据和互动数据__: Rocket会向我们发送我们所建议内容的位置、大小和定位等数据，以及与Rocket建议内容交互的基本数据。这包括建议内容显示或被点击的次数。
-
+* __技术数据和互动数据__: Firefox Lite会向我们发送我们所建议内容的位置、大小和定位等数据，以及与Firefox Lite建议内容交互的基本数据。这包括建议内容显示或被点击的次数。
 
 ### 衡量并配合我们的营销活动
 
-* __推荐和营销活动数据__: 为了帮助改善我们的营销活动，Rocket可能会使用网站域名或广告活动等“推荐数据”来推荐您下载并安装Rocket。这些数据由我们的分析供应商保存，并在您启动Rocket时提供，并且还包含iOS供应商ID或Google广告ID、时间戳、国家/地区、语言环境、操作系统和应用程序版本。
+* __推荐和营销活动数据__: 为了帮助改善我们的营销活动，Firefox Lite可能会使用网站域名或广告活动等“推荐数据”来推荐您下载并安装Firefox Lite。这些数据由我们的分析供应商保存，并在您启动Firefox Lite时提供，并且还包含iOS供应商ID或Google广告ID、时间戳、国家/地区、语言环境、操作系统和应用程序版本。
 
-详细了解[推荐和营销活动数据](https://github.com/mozilla-tw/Rocket/wiki/Telemetry#install-campaign-tracking)或如何[退出](https://support.mozilla.org/kb/send-usage-data-firefox-mobile-devices)此数据收集。
+详细了解[推荐和营销活动数据](https://github.com/mozilla-tw/Firefox-Lite/wiki/Telemetry#install-campaign-tracking)或如何[退出](https://support.mozilla.org/kb/send-usage-data-firefox-mobile-devices)此数据收集。
 
 ---
 
-## 如果您使用以下这些功能，Rocket将共享数据以提供功能： {: #optional-features }
+## 如果您使用以下这些功能，Firefox Lite将共享数据以提供功能： {: #optional-features }
 
 ### 搜索
 
-您可以直接从Rocket的搜索栏执行搜索。  _Mozilla不会收到您的搜索查询。_ 查询数据将发送到您的搜索提供商，该提供商有自己的隐私政策。  
+您可以直接从Firefox Lite的搜索栏执行搜索。  _Mozilla不会收到您的搜索查询。_ 查询数据将发送到您的搜索提供商，该提供商有自己的隐私政策。  
 
-* __搜索建议__: 默认情况下，Rocket会将搜索查询发送给您的搜索提供商，以帮助您发现其他用户搜索的常用短语并改善您的搜索体验。如果您选择的搜索提供商不支持搜索建议，则不会发送这些数据。
+* __搜索建议__: 默认情况下，Firefox Lite会将搜索查询发送给您的搜索提供商，以帮助您发现其他用户搜索的常用短语并改善您的搜索体验。如果您选择的搜索提供商不支持搜索建议，则不会发送这些数据。
 {: #searchsuggestions }
     
 ### 位置 {: #location-services }
 
-* __发送定位数据到谷歌的地理位置服务__: 在确定您的位置并共享给请求的网站之前，Rocket始终会询问（例如，当某个地图网站需要您的位置以提供路线指示时）。为了确定位置，Rocket可能会使用您的操作系统的地理位置功能、Wi-Fi网络、手机信号塔或IP地址，并可能会将此数据发送给Google的地理定位服务，该服务有自己[的隐私政策](https://www.google.com/privacy/lsf.html).
+* __发送定位数据到谷歌的地理位置服务__: 在确定您的位置并共享给请求的网站之前，Firefox Lite始终会询问（例如，当某个地图网站需要您的位置以提供路线指示时）。为了确定位置，Firefox Lite可能会使用您的操作系统的地理位置功能、Wi-Fi网络、手机信号塔或IP地址，并可能会将此数据发送给Google的地理定位服务，该服务有自己[的隐私政策](https://www.google.com/privacy/lsf.html).
 
 [了解更多](https://www.mozilla.org/firefox/geolocation/).
 
@@ -54,7 +53,7 @@ Rocket会显示内容，例如热门网站（由Mozilla为Rocket新用户推荐�
 
 ### 脚注
 
-本隐私声明适用于Mozilla发布的Rocket最新通用版本。如果您是从其他地方获得Rocket或正在运行旧版本，则您的Rocket版本可能包含不同的隐私规定。
+本隐私声明适用于Mozilla发布的Firefox Lite最新通用版本。如果您是从其他地方获得Firefox Lite或正在运行旧版本，则您的Firefox Lite版本可能包含不同的隐私规定。
 {: #pre-release }
 
-Mozilla的预发布版Rocket（通过诸如Nightly、Beta、Google Play和BuddyBuild等渠道分发）正在积极开发中，可能包含不同的隐私规定。
+Mozilla的预发布版Firefox Lite（通过诸如Nightly、Beta、Google Play和BuddyBuild等渠道分发）正在积极开发中，可能包含不同的隐私规定。


### PR DESCRIPTION
- HTML tag
- Telemetry URLs
- Content

@pmac I also changed the Header formatting tag firefox-rocket to firefox-lite. 