### PR TITLE
Firefox Rocket and Rocket to Firefox Lite - id

### DIFF
--- a/rocket_privacy_notice/id.md
+++ b/rocket_privacy_notice/id.md
@@ -1,54 +1,54 @@
-## <span class="privacy-header-firefox-rocket">Pemberitahuan Privasi</span> <span class="privacy-header-policy">Firefox Rocket</span>
+## <span class="privacy-header-firefox-lite">Pemberitahuan Privasi</span> <span class="privacy-header-policy">Firefox Lite</span>
 
 11 Mei 2018
 {: datetime="2018-5-11" }
 
 ## Di Mozilla, kami yakin bahwa privasi sangat penting untuk menciptakan internet yang sehat.
 
-Itulah sebabnya kami membuat Firefox Rocket, dan semua produk kami, untuk memberi Anda kontrol yang lebih besar atas informasi yang Anda bagikan di internet dan informasi yang Anda bagikan kepada kami. Kami berusaha untuk hanya mengumpulkan apa yang kami perlukan untuk meningkatkan Rocket bagi semua orang.
+Itulah sebabnya kami membuat Firefox Lite, dan semua produk kami, untuk memberi Anda kontrol yang lebih besar atas informasi yang Anda bagikan di internet dan informasi yang Anda bagikan kepada kami. Kami berusaha untuk hanya mengumpulkan apa yang kami perlukan untuk meningkatkan Firefox Lite bagi semua orang.
  
-Dalam Kebijakan Privasi ini, kami menjelaskan apa saja data yang dibagikan Rocket dan mengarahkan Anda ke pengaturan untuk membagikan lebih sedikit informasi. Kami juga mematuhi praktik yang dijabarkan dalam [kebijakan privasi](https://www.mozilla.org/privacy/) Mozilla tentang cara kami menerima, menangani, dan membagikan informasi yang kami kumpulkan dari Rocket.
+Dalam Kebijakan Privasi ini, kami menjelaskan apa saja data yang dibagikan Firefox Lite dan mengarahkan Anda ke pengaturan untuk membagikan lebih sedikit informasi. Kami juga mematuhi praktik yang dijabarkan dalam [kebijakan privasi](https://www.mozilla.org/privacy/) Mozilla tentang cara kami menerima, menangani, dan membagikan informasi yang kami kumpulkan dari Firefox Lite.
 
-## Firefox Rocket secara baku membagikan data untuk:
+## Firefox Lite secara baku membagikan data untuk:
 
 ### Meningkatkan kinerja dan stabilitas bagi pengguna di mana pun berada
 
-* __Data interaksi__: Rocket mengirimkan data tentang interaksi Anda dengan Rocket kepada kami (seperti jumlah laman web yang dikunjungi; serta panjang sesi) dan fitur-fitur Rocket yang ditawarkan oleh Mozilla atau mitra kami (seperti interaksi dengan fitur pencarian dan perujuk mitra pencarian Rocket).
+* __Data interaksi__: Firefox Lite mengirimkan data tentang interaksi Anda dengan Firefox Lite kepada kami (seperti jumlah laman web yang dikunjungi; serta panjang sesi) dan fitur-fitur Firefox Lite yang ditawarkan oleh Mozilla atau mitra kami (seperti interaksi dengan fitur pencarian dan perujuk mitra pencarian Firefox Lite).
 
-* __Data teknis__: Rocket mengirimkan data tentang versi dan bahasa Rocket Anda; sistem operasi perangkat dan konfigurasi perangkat keras; memori, informasi dasar tentang kerusakan dan kesalahan; hasil proses otomatis seperti pembaruan dan aktivasi kepada kami.  Saat Rocket mengirimkan data kepada kami, alamat IP Anda akan sementara dikumpulkan sebagai bagian dari log server kami.  
+* __Data teknis__: Firefox Lite mengirimkan data tentang versi dan bahasa Firefox Lite Anda; sistem operasi perangkat dan konfigurasi perangkat keras; memori, informasi dasar tentang kerusakan dan kesalahan; hasil proses otomatis seperti pembaruan dan aktivasi kepada kami.  Saat Firefox Lite mengirimkan data kepada kami, alamat IP Anda akan sementara dikumpulkan sebagai bagian dari log server kami.  
 
-Baca dokumen selengkapnya untuk Rocket [di sini](https://github.com/mozilla-tw/Rocket/wiki/Telemetry) atau nonaktifkan fitur “Kirim Data Penggunaan” di Pengaturan Anda.
+Baca dokumen selengkapnya untuk Firefox Lite [di sini](https://github.com/mozilla-tw/Firefox-Lite/wiki/Telemetry) atau nonaktifkan fitur “Kirim Data Penggunaan” di Pengaturan Anda.
 {: #telemetry }
 
 ### Menyarankan konten yang relevan
 
-Rocket menampilkan konten, seperti Situs Populer (situs web yang disarankan oleh Mozilla kepada pengguna yang baru pertama kali menggunakan Rocket).
+Firefox Lite menampilkan konten, seperti Situs Populer (situs web yang disarankan oleh Mozilla kepada pengguna yang baru pertama kali menggunakan Firefox Lite).
 
-* __Data Teknis & Interaksi__: Rocket mengirimi kami data seperti posisi, ukuran, dan letak konten yang kami sarankan, serta data dasar tentang interaksi Anda dengan konten yang disarankan Rocket. Data ini termasuk berapa kali konten yang disarankan tersebut ditampilkan atau diklik.
+* __Data Teknis & Interaksi__: Firefox Lite mengirimi kami data seperti posisi, ukuran, dan letak konten yang kami sarankan, serta data dasar tentang interaksi Anda dengan konten yang disarankan Firefox Lite. Data ini termasuk berapa kali konten yang disarankan tersebut ditampilkan atau diklik.
 
 ### Mengukur dan mendukung pemasaran kami
 
-* __Data Perujuk dan Pemasaran__: Untuk membantu meningkatkan kampanye pemasaran kami, Rocket mungkin menggunakan “Data Perujuk” seperti domain situs web atau pemasaran iklan yang merekomendasikan Anda untuk mengunduh dan memasang Rocket. Data ini disimpan oleh vendor analitika kami dan diberikan saat Anda memulai Rocket, serta mencakup ID iklan Google, stempel waktu, negara, bahasa, sistem operasi, dan versi aplikasi. Kami juga dapat menggunakan vendor pihak ketiga untuk mengelola program perujuk dan menangani data apa pun yang Anda pilih untuk dikirimkan.
+* __Data Perujuk dan Pemasaran__: Untuk membantu meningkatkan kampanye pemasaran kami, Firefox Lite mungkin menggunakan “Data Perujuk” seperti domain situs web atau pemasaran iklan yang merekomendasikan Anda untuk mengunduh dan memasang Firefox Lite. Data ini disimpan oleh vendor analitika kami dan diberikan saat Anda memulai Firefox Lite, serta mencakup ID iklan Google, stempel waktu, negara, bahasa, sistem operasi, dan versi aplikasi. Kami juga dapat menggunakan vendor pihak ketiga untuk mengelola program perujuk dan menangani data apa pun yang Anda pilih untuk dikirimkan.
 
-Pelajari selengkapnya tentang [Data Perujuk dan Pemasaran](https://github.com/mozilla-tw/Rocket/wiki/Telemetry#install-campaign-tracking).
+Pelajari selengkapnya tentang [Data Perujuk dan Pemasaran](https://github.com/mozilla-tw/Firefox-Lite/wiki/Telemetry#install-campaign-tracking).
 
 ### Meningkatkan produk kami berdasarkan umpan balik Anda
 
-Untuk membantu kami meningkatkan kinerja, memberikan dukungan terkait kerusakan, memahami pengalaman Anda menggunakan Rocket serta meningkatkan pengalaman pengguna melalui A/B testing dan perpesanan dalam produk, Firefox Rocket menggunakan platform Firebase Google, yang menerima data dari perangkat Anda. Pelajari selengkapnya tentang pengumpulan data Firebase atau nonaktifkan fitur “Kirim Data Penggunaan” di Pengaturan Anda.
+Untuk membantu kami meningkatkan kinerja, memberikan dukungan terkait kerusakan, memahami pengalaman Anda menggunakan Firefox Lite serta meningkatkan pengalaman pengguna melalui A/B testing dan perpesanan dalam produk, Firefox Firefox Lite menggunakan platform Firebase Google, yang menerima data dari perangkat Anda. Pelajari selengkapnya tentang pengumpulan data Firebase atau nonaktifkan fitur “Kirim Data Penggunaan” di Pengaturan Anda.
 
 ---
 
-## Jika Anda menggunakan fitur ini, Rocket akan membagikan data untuk menyediakan fungsi: {: #optional-features }
+## Jika Anda menggunakan fitur ini, Firefox Lite akan membagikan data untuk menyediakan fungsi: {: #optional-features }
 
 ### Pencarian
 
-Anda bisa melakukan pencarian langsung dari bilah pencarian di Rocket.  _Mozilla tidak menerima kueri pencarian Anda._ Data kueri dikirim ke penyedia pencarian Anda, yang memiliki kebijakan privasi sendiri.  
+Anda bisa melakukan pencarian langsung dari bilah pencarian di Firefox Lite.  _Mozilla tidak menerima kueri pencarian Anda._ Data kueri dikirim ke penyedia pencarian Anda, yang memiliki kebijakan privasi sendiri.  
 
-* __Saran Pencarian__: Rocket secara baku mengirimkan kueri pencarian kepada penyedia pencarian Anda untuk membantu Anda menemukan frasa umum yang sudah dicari orang lain dan meningkatkan pengalaman pencarian Anda. Data ini tidak akan dikirimkan jika penyedia pencarian yang Anda pilih tidak mendukung saran pencarian.
+* __Saran Pencarian__: Firefox Lite secara baku mengirimkan kueri pencarian kepada penyedia pencarian Anda untuk membantu Anda menemukan frasa umum yang sudah dicari orang lain dan meningkatkan pengalaman pencarian Anda. Data ini tidak akan dikirimkan jika penyedia pencarian yang Anda pilih tidak mendukung saran pencarian.
 {: #searchsuggestions }
     
 ### Lokasi {: #location-services }
 
-* __Data lokasi ke layanan geolokasi Google__: Rocket akan selalu bertanya sebelum menentukan dan membagikan lokasi Anda kepada situs web yang memintanya (misalnya, jika situs web peta memerlukan lokasi Anda untuk memberikan petunjuk arah).  Untuk menentukan lokasi, Rocket bisa menggunakan fitur geolokasi sistem operasi Anda, jaringan Wi-fi, tower ponsel, atau alamat IP, dan mungkin mengirimkan data ini ke layanan geolokasi Google, yang memiliki [kebijakan privasi sendiri](https://www.google.com/privacy/lsf.html).
+* __Data lokasi ke layanan geolokasi Google__: Firefox Lite akan selalu bertanya sebelum menentukan dan membagikan lokasi Anda kepada situs web yang memintanya (misalnya, jika situs web peta memerlukan lokasi Anda untuk memberikan petunjuk arah).  Untuk menentukan lokasi, Firefox Lite bisa menggunakan fitur geolokasi sistem operasi Anda, jaringan Wi-fi, tower ponsel, atau alamat IP, dan mungkin mengirimkan data ini ke layanan geolokasi Google, yang memiliki [kebijakan privasi sendiri](https://www.google.com/privacy/lsf.html).
 
 [Pelajari selengkapnya.](https://www.mozilla.org/firefox/geolocation/)


### PR DESCRIPTION
HTML tag
Telemetry URLs
Content

@pmac I also changed the Header formatting tag firefox-rocket to firefox-lite.