### PR TITLE
updates Lockbox -> Lockwise and updates privacy links

### DIFF
--- a/firefox_cloud_services_ToS/de.md
+++ b/firefox_cloud_services_ToS/de.md
@@ -48,7 +48,7 @@ Dieser vorangestellte Abschnitt fasst die unten im Einzelnen genannten Bedingung
 
     Wir verwenden die über die Services erhaltenen Daten wie in der [Mozilla-Datenschutzerklärung](https://www.mozilla.org/privacy/) beschrieben. Unsere Datenschutzhinweise beschreiben ausführlicher, welche Daten wir von jedem Service erhalten:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/de.md
+++ b/firefox_cloud_services_ToS/de.md
@@ -48,7 +48,7 @@ Dieser vorangestellte Abschnitt fasst die unten im Einzelnen genannten Bedingung
 
     Wir verwenden die über die Services erhaltenen Daten wie in der [Mozilla-Datenschutzerklärung](https://www.mozilla.org/privacy/) beschrieben. Unsere Datenschutzhinweise beschreiben ausführlicher, welche Daten wir von jedem Service erhalten:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/en-US.md
+++ b/firefox_cloud_services_ToS/en-US.md
@@ -48,7 +48,7 @@ This top section summarizes the terms below. This summary is provided to help yo
 
     We use the information we receive through the Services as described in our [Mozilla Privacy Policy](https://www.mozilla.org/privacy/). Our Privacy Notices describe in more detail the data we receive from each service:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/) 
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal) 

--- a/firefox_cloud_services_ToS/en-US.md
+++ b/firefox_cloud_services_ToS/en-US.md
@@ -48,7 +48,7 @@ This top section summarizes the terms below. This summary is provided to help yo
 
     We use the information we receive through the Services as described in our [Mozilla Privacy Policy](https://www.mozilla.org/privacy/). Our Privacy Notices describe in more detail the data we receive from each service:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/) 
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal) 

--- a/firefox_cloud_services_ToS/es-ES.md
+++ b/firefox_cloud_services_ToS/es-ES.md
@@ -46,7 +46,7 @@ Esta sección inicial resume las condiciones descritas a continuación. El prese
 
     Utilizamos la información que recibimos a través de los Servicios tal y como se describe en la [Política de privacidad de Mozilla](https://www.mozilla.org/privacy/). Nuestros Avisos de privacidad especifican de forna detallada la información que recibimos de estos servicios:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/es-ES.md
+++ b/firefox_cloud_services_ToS/es-ES.md
@@ -24,7 +24,7 @@ Esta sección inicial resume las condiciones descritas a continuación. El prese
 
     (a) Firefox Screenshots le permite capturar contenido web para que usted y otros usuarios puedan verlo en otro momento. 
     
-    (b) Firefox Lockbox le permite acceder a sus contraseñas guardadas en Firefox desde todos sus dispositivos. Este servicio requiere una cuenta de Firefox.
+    (b) Firefox Lockwise le permite acceder a sus contraseñas guardadas en Firefox desde todos sus dispositivos. Este servicio requiere una cuenta de Firefox.
 
     (c) Firefox Monitor es un servicio informativo para promover la seguridad online informándole acerca de las infracciones relacionadas con los datos públicos. Puede consultar las direcciones de correo electrónico indicadas en nuestro sitio web para conocer las filtraciones más conocidas públicamente. Si se suscribe con una cuenta de Firefox, recibirá: 
 
@@ -46,7 +46,7 @@ Esta sección inicial resume las condiciones descritas a continuación. El prese
 
     Utilizamos la información que recibimos a través de los Servicios tal y como se describe en la [Política de privacidad de Mozilla](https://www.mozilla.org/privacy/). Nuestros Avisos de privacidad especifican de forna detallada la información que recibimos de estos servicios:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/fr.md
+++ b/firefox_cloud_services_ToS/fr.md
@@ -48,7 +48,7 @@ Cette première section offre un résumé des conditions d’utilisation. Ce ré
 
     Les informations que nous recevons via les Services sont utilisées conformément à la [Politique de confidentialité de Mozilla](https://www.mozilla.org/privacy/). Nos avis de confidentialité offrent une description plus détaillée des données que nous recevons de chaque service :
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/fr.md
+++ b/firefox_cloud_services_ToS/fr.md
@@ -48,7 +48,7 @@ Cette première section offre un résumé des conditions d’utilisation. Ce ré
 
     Les informations que nous recevons via les Services sont utilisées conformément à la [Politique de confidentialité de Mozilla](https://www.mozilla.org/privacy/). Nos avis de confidentialité offrent une description plus détaillée des données que nous recevons de chaque service :
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/id.md
+++ b/firefox_cloud_services_ToS/id.md
@@ -46,7 +46,7 @@ Bagian atas ini merangkum ketentuan di bawah ini. Rangkuman ini dibuat untuk mem
 
     Kami menggunakan informasi yang kami terima melalui dari Layanan seperti yang dijelaskan dalam [Kebijakan Privasi Mozilla](https://www.mozilla.org/privacy/) kami. Pemberitahuan Privasi kami menjelaskan data yang kami terima dari setiap layanan secara lebih rinci:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/id.md
+++ b/firefox_cloud_services_ToS/id.md
@@ -24,7 +24,7 @@ Bagian atas ini merangkum ketentuan di bawah ini. Rangkuman ini dibuat untuk mem
 
     (a) Firefox Screenshots memungkinkan Anda menangkap isi halaman web yang nantinya bisa dilihat Anda atau orang lain. 
     
-    (b) Firefox Lockbox memungkinkan Anda mengakses kata sandi yang disimpan ke Firefox melalui berbagai perangkat. Diperlukan Akun Firefox. 
+    (b) Firefox Lockwise memungkinkan Anda mengakses kata sandi yang disimpan ke Firefox melalui berbagai perangkat. Diperlukan Akun Firefox. 
 
     (c) Firefox Monitor adalah layanan informasi untuk mendukung keamanan online dengan memberi tahu Anda tentang pelanggaran data publik. Anda dapat memindai alamat email di situs web kami untuk melihat sebagian besar pelanggaran yang diketahui publik. Jika Anda berlangganan Akun Firefox, Anda akan menerima: 
 
@@ -46,7 +46,7 @@ Bagian atas ini merangkum ketentuan di bawah ini. Rangkuman ini dibuat untuk mem
 
     Kami menggunakan informasi yang kami terima melalui dari Layanan seperti yang dijelaskan dalam [Kebijakan Privasi Mozilla](https://www.mozilla.org/privacy/) kami. Pemberitahuan Privasi kami menjelaskan data yang kami terima dari setiap layanan secara lebih rinci:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/it.md
+++ b/firefox_cloud_services_ToS/it.md
@@ -46,7 +46,7 @@ La sezione in alto riepiloga i termini descritti sotto. Questo riepilogo viene f
 
     Le informazioni ricevute attraverso i Servizi vengono utilizzate come descritto nella[Politica sulla Privacy di Mozilla](https://www.mozilla.org/privacy/). Gli Avvisi sulla privacy descrivono più nel dettaglio i dati che riceviamo da ciascun servizio:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/it.md
+++ b/firefox_cloud_services_ToS/it.md
@@ -24,7 +24,7 @@ La sezione in alto riepiloga i termini descritti sotto. Questo riepilogo viene f
 
     (a) Firefox Screenshots consente di catturare il contenuto di una pagina web da visualizzare in un secondo momento. 
     
-    (b) Firefox Lockbox consente di accedere a password salvate in Firefox da diversi dispositivi. Per utilizzare questo servizio è richiesto un account Firefox. 
+    (b) Firefox Lockwise consente di accedere a password salvate in Firefox da diversi dispositivi. Per utilizzare questo servizio è richiesto un account Firefox. 
 
     (c) Firefox Monitor è un servizio informativo finalizzato a promuovere la sicurezza online tramite la diffusione di informazioni su violazioni pubbliche dei dati. È possibile eseguire la scansione di propri indirizzi e-mail sul nostro sito web per sapere se sono stati esposti a violazioni pubbliche conosciute. L'iscrizione con un account Firefox dà diritto a quanto segue: 
 
@@ -46,7 +46,7 @@ La sezione in alto riepiloga i termini descritti sotto. Questo riepilogo viene f
 
     Le informazioni ricevute attraverso i Servizi vengono utilizzate come descritto nella[Politica sulla Privacy di Mozilla](https://www.mozilla.org/privacy/). Gli Avvisi sulla privacy descrivono più nel dettaglio i dati che riceviamo da ciascun servizio:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/ja.md
+++ b/firefox_cloud_services_ToS/ja.md
@@ -46,7 +46,7 @@
 
     Mozilla は、本サービスを通じて受信する情報を、[Mozilla プライバシーポリシー](https://www.mozilla.org/privacy/)の記載に従って利用します。弊社のプライバシーポリシーには、弊社が以下の各サービスから受け取るデータについての詳細が記載されています。
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/ja.md
+++ b/firefox_cloud_services_ToS/ja.md
@@ -24,7 +24,7 @@
 
     (a) Firefox Screenshots を使用すると、ウェブページのコンテンツをキャプチャすることで、後でご自分または他の人がそのコンテンツを見ることができます。
     
-	(b) Firefox Lockbox を使用すると、複数のデバイスから、Firefox に保存したパスワードにアクセスできます。Firefox アカウントが必要です。
+	(b) Firefox Lockwise を使用すると、複数のデバイスから、Firefox に保存したパスワードにアクセスできます。Firefox アカウントが必要です。
 
     (c) Firefox Monitor は、公共の場でのデータ漏洩を皆様にお知らせすることでオンライン上のセキュリティを強化する、情報提供サービスです。弊社ウェブサイトでメールアドレスをスキャンして、公に知られている違反を確認できます。Firefox アカウントを使って契約されている場合は、以下の情報が送られてきます。
 
@@ -46,7 +46,7 @@
 
     Mozilla は、本サービスを通じて受信する情報を、[Mozilla プライバシーポリシー](https://www.mozilla.org/privacy/)の記載に従って利用します。弊社のプライバシーポリシーには、弊社が以下の各サービスから受け取るデータについての詳細が記載されています。
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/nl.md
+++ b/firefox_cloud_services_ToS/nl.md
@@ -24,7 +24,7 @@ Dit bovenste gedeelte biedt een overzicht van de voorwaarden hieronder. Dit over
 
     (a) Met Firefox Screenshots kunt u webpagina-inhoud vastleggen die door u of anderen kan worden bekeken. 
     
-    (b) Firefox Lockbox biedt u op meerdere apparaten toegang tot wachtwoorden die naar Firefox zijn opgeslagen. Er is een Firefox-account vereist. 
+    (b) Firefox Lockwise biedt u op meerdere apparaten toegang tot wachtwoorden die naar Firefox zijn opgeslagen. Er is een Firefox-account vereist. 
 
     (c) Firefox Monitor is een informatieve service voor het bevorderen van online veiligheid door u in kennis te stellen van openbare gegevensinbreuken. U kunt e-mailadressen op onze website scannen om de bekendste inbreuken te bekijken. Als u zich inschrijft met een Firefox-account, ontvangt u: 
 
@@ -46,7 +46,7 @@ Dit bovenste gedeelte biedt een overzicht van de voorwaarden hieronder. Dit over
 
     We gebruiken de informatie die we ontvangen via de Services op de wijze die is beschreven in ons [Mozilla-privacybeleid](https://www.mozilla.org/privacy/). Onze Privacyverklaringen beschrijven op een uitgebreidere wijze de gegevens die we via de afzonderlijke services ontvangen:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/nl.md
+++ b/firefox_cloud_services_ToS/nl.md
@@ -46,7 +46,7 @@ Dit bovenste gedeelte biedt een overzicht van de voorwaarden hieronder. Dit over
 
     We gebruiken de informatie die we ontvangen via de Services op de wijze die is beschreven in ons [Mozilla-privacybeleid](https://www.mozilla.org/privacy/). Onze Privacyverklaringen beschrijven op een uitgebreidere wijze de gegevens die we via de afzonderlijke services ontvangen:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/pl.md
+++ b/firefox_cloud_services_ToS/pl.md
@@ -24,7 +24,7 @@ Niniejsza najwyższa sekcja zawiera streszczenie poniższych warunków. Streszcz
 
     (a) Funkcja Firefox Screenshots umożliwia przechwytywanie zawartości strony internetowej w celu późniejszego wyświetlenia przez użytkownika lub inne osoby. 
     
-    (b) Funkcja Firefox Lockbox umożliwia uzyskiwanie dostępu do haseł zapisanych w przeglądarce Firefox na wielu urządzeniach. Wymagane jest konto Firefox. 
+    (b) Funkcja Firefox Lockwise umożliwia uzyskiwanie dostępu do haseł zapisanych w przeglądarce Firefox na wielu urządzeniach. Wymagane jest konto Firefox. 
 
     (c) Firefox Monitor to usługa informacyjna promująca bezpieczeństwo podczas korzystania z Internetu, która informuje użytkownika o publicznych wyciekach danych. Użytkownik może skanować adresy e-mail w naszej witrynie w celu wyświetlania informacji dotyczących najbardziej znanych, publicznych wycieków danych. Utworzenie subskrypcji za pomocą konta Firefox umożliwia dostęp do następującej zawartości: 
 
@@ -46,7 +46,7 @@ Niniejsza najwyższa sekcja zawiera streszczenie poniższych warunków. Streszcz
 
     Z informacji otrzymanych za pośrednictwem Usług korzystamy zgodnie z postanowieniami dokumentu [Polityka prywatności Mozilla](https://www.mozilla.org/privacy/). Nasze zasady prywatności określają bardziej szczegółowo dane, które otrzymujemy z każdej usługi:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/pl.md
+++ b/firefox_cloud_services_ToS/pl.md
@@ -46,7 +46,7 @@ Niniejsza najwyższa sekcja zawiera streszczenie poniższych warunków. Streszcz
 
     Z informacji otrzymanych za pośrednictwem Usług korzystamy zgodnie z postanowieniami dokumentu [Polityka prywatności Mozilla](https://www.mozilla.org/privacy/). Nasze zasady prywatności określają bardziej szczegółowo dane, które otrzymujemy z każdej usługi:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/pt-BR.md
+++ b/firefox_cloud_services_ToS/pt-BR.md
@@ -46,7 +46,7 @@ Esta seção resume os termos abaixo. Este resumo pretende ajudá-lo a compreend
 
     Utilizamos as informações recebidas pelos Serviços conforme descrito em nossa [Política de privacidade da Mozilla](https://www.mozilla.org/privacy/). Nossos Avisos de privacidade descrevem os dados que recebemos de cada serviço em mais detalhes:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/pt-BR.md
+++ b/firefox_cloud_services_ToS/pt-BR.md
@@ -24,7 +24,7 @@ Esta seção resume os termos abaixo. Este resumo pretende ajudá-lo a compreend
 
     (a) As capturas de tela do Firefox permitem capturar conteúdo de páginas da internet para ser visualizado posteriormente por você ou outras pessoas. 
     
-    (b) O Firefox Lockbox permite acessar senhas salvas no Firefox em diferentes dispositivos. É necessário ter uma conta do Firefox. 
+    (b) O Firefox Lockwise permite acessar senhas salvas no Firefox em diferentes dispositivos. É necessário ter uma conta do Firefox. 
 
     (c) O Firefox Monitor é um serviço de informações que promove a segurança on-line ao informá-lo sobre violações de dados. É possível verificar endereços de e-mail no nosso site para ver as violações mais comuns. Se você se inscrever em uma conta do Firefox, receberá: 
 
@@ -46,7 +46,7 @@ Esta seção resume os termos abaixo. Este resumo pretende ajudá-lo a compreend
 
     Utilizamos as informações recebidas pelos Serviços conforme descrito em nossa [Política de privacidade da Mozilla](https://www.mozilla.org/privacy/). Nossos Avisos de privacidade descrevem os dados que recebemos de cada serviço em mais detalhes:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/ru.md
+++ b/firefox_cloud_services_ToS/ru.md
@@ -46,7 +46,7 @@
 
     Информация, полученная с помощью Сервисов, используется в соответствии с [Политикой конфиденциальности Mozilla](https://www.mozilla.org/privacy/). Наша Политика конфиденциальности описывает более подробно сведения, которые мы получаем через каждый сервис:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/ru.md
+++ b/firefox_cloud_services_ToS/ru.md
@@ -24,7 +24,7 @@
 
     (a) Сервис Firefox Screenshots позволяет сохранять контент веб-страниц, который может быть просмотрен позже вами или другими пользователями. 
     
-    (b) Сервис Firefox Lockbox позволяет получить доступ к паролям, сохраненным в Firefox на разных устройствах. Требуется аккаунт Firefox. 
+    (b) Сервис Firefox Lockwise позволяет получить доступ к паролям, сохраненным в Firefox на разных устройствах. Требуется аккаунт Firefox. 
 
     (c) Firefox Monitor - информационный сервис для продвижения мер по онлайн-безопасности и информирования пользователей о нарушениях  в отношении общедоступных данных. Вы можете проверить адреса электронной почты на нашем сайте, чтобы увидеть наиболее распространенные нарушения. Если вы подпишетесь с помощью аккаунта Firefox , вы получите: 
 
@@ -46,7 +46,7 @@
 
     Информация, полученная с помощью Сервисов, используется в соответствии с [Политикой конфиденциальности Mozilla](https://www.mozilla.org/privacy/). Наша Политика конфиденциальности описывает более подробно сведения, которые мы получаем через каждый сервис:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/tr.md
+++ b/firefox_cloud_services_ToS/tr.md
@@ -46,7 +46,7 @@ Son Güncelleme: 10 Eylül 2019 Salı
 
     Hizmetler aracılığıyla aldığımız bilgileri [Mozilla Gizlilik Politikamızda](https://www.mozilla.org/privacy/) açıklandığı şekilde kullanırız. Gizlilik Bildirimlerimiz, her bir hizmetten aldığımız verileri daha ayrıntılı olarak açıklar:
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/tr.md
+++ b/firefox_cloud_services_ToS/tr.md
@@ -24,7 +24,7 @@ Son Güncelleme: 10 Eylül 2019 Salı
 
     (a) Firefox Screenshots, daha sonra siz veya başkaları tarafından görüntülenebilecek web sayfası içeriklerini yakalamanıza izin verir. 
     
-    (b) Firefox Lockbox, cihazlar genelinde Firefox’a kaydedilen şifrelere erişmenize izin verir. Firefox Hesabı gereklidir. 
+    (b) Firefox Lockwise, cihazlar genelinde Firefox’a kaydedilen şifrelere erişmenize izin verir. Firefox Hesabı gereklidir. 
 
     (c) Firefox Monitor, herkese açık veri ihlalleri konusunda sizi bilgilendirerek çevrimiçi güvenliği güçlendiren bir bilgilendirme hizmetidir. En bilinen herkese açık veri ihlallerini görüntülemek için web sitenizdeki e-posta adreslerini tarayabilirsiniz. Bir Firefox Hesabı ile kayıt yaptırırsanız, aşağıdakileri alırsınız: 
 
@@ -46,7 +46,7 @@ Son Güncelleme: 10 Eylül 2019 Salı
 
     Hizmetler aracılığıyla aldığımız bilgileri [Mozilla Gizlilik Politikamızda](https://www.mozilla.org/privacy/) açıklandığı şekilde kullanırız. Gizlilik Bildirimlerimiz, her bir hizmetten aldığımız verileri daha ayrıntılı olarak açıklar:
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/zh-CN.md
+++ b/firefox_cloud_services_ToS/zh-CN.md
@@ -24,7 +24,7 @@
 
     (a) Firefox Screenshots 允许您捕获网页内容，便于您本人或他人稍后查看。
     
-	(b) Firefox Lockbox 允许您访问不同设备保存到 Firefox 的密码。必需具有 Firefox 帐户。
+	(b) Firefox Lockwise 允许您访问不同设备保存到 Firefox 的密码。必需具有 Firefox 帐户。
 
     (c) Firefox Monitor 是一项信息服务，它会在发生公共数据泄露时发出通知，从而加强在线安全性。您可以扫描我们网站中的电子邮件地址，了解大部分公开泄露事件。如果使用 Firefox 帐户订阅服务，您将会获得：
 
@@ -46,7 +46,7 @@
 
     我们将根据 [Mozilla 隐私政策](https://www.mozilla.org/privacy/)的规定使用通过 Services 接收的信息。隐私声明更详细地描述了我们通过各项服务接收的数据：
 
-    * [Firefox Lockbox](https://lockbox.firefox.com/privacy.html)
+    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_cloud_services_ToS/zh-CN.md
+++ b/firefox_cloud_services_ToS/zh-CN.md
@@ -46,7 +46,7 @@
 
     我们将根据 [Mozilla 隐私政策](https://www.mozilla.org/privacy/)的规定使用通过 Services 接收的信息。隐私声明更详细地描述了我们通过各项服务接收的数据：
 
-    * [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+    * [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
     * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor/)
     * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
     * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/de.md
+++ b/firefox_privacy_notice/de.md
@@ -110,7 +110,7 @@ __Suchempfehlungen__: Firefox sendet Suchanfragen standardmäßig an Ihren Sucha
 
 Lesen Sie die vollständige Dokumentation oder erhalten Sie weitere Informationen, z. B. zur Verwaltung Ihrer Firefox-Kontodaten oder zu unseren Datenpraktiken für [Websites und E-Mail](https://www.mozilla.org/privacy/websites/). Sie können auch die Datenschutzhinweise zu den mit Ihrem Firefox-Konto verbundenen Services lesen. Dabei handelt es sich um: 
 
-* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+* [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/de.md
+++ b/firefox_privacy_notice/de.md
@@ -110,7 +110,7 @@ __Suchempfehlungen__: Firefox sendet Suchanfragen standardmäßig an Ihren Sucha
 
 Lesen Sie die vollständige Dokumentation oder erhalten Sie weitere Informationen, z. B. zur Verwaltung Ihrer Firefox-Kontodaten oder zu unseren Datenpraktiken für [Websites und E-Mail](https://www.mozilla.org/privacy/websites/). Sie können auch die Datenschutzhinweise zu den mit Ihrem Firefox-Konto verbundenen Services lesen. Dabei handelt es sich um: 
 
-* [Firefox Lockwise](https://lockbox.firefox.com/privacy.html)
+* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/en-US.md
+++ b/firefox_privacy_notice/en-US.md
@@ -110,7 +110,7 @@ __Search Suggestions__: Firefox by default sends search queries to your search p
 
 Read the full documentation or learn more, including how to manage your Firefox Account data or our data practices for [websites and email](https://www.mozilla.org/privacy/websites/).  You can also read the privacy notices for our Firefox Account connected services, which are: 
 
-* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+* [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/en-US.md
+++ b/firefox_privacy_notice/en-US.md
@@ -110,7 +110,7 @@ __Search Suggestions__: Firefox by default sends search queries to your search p
 
 Read the full documentation or learn more, including how to manage your Firefox Account data or our data practices for [websites and email](https://www.mozilla.org/privacy/websites/).  You can also read the privacy notices for our Firefox Account connected services, which are: 
 
-* [Firefox Lockwise](https://lockbox.firefox.com/privacy.html)
+* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/fr.md
+++ b/firefox_privacy_notice/fr.md
@@ -110,7 +110,7 @@ __Suggestions de recherche__ : Firefox envoie par défaut les requêtes de rech
 
 Lisez la documentation complète ou apprenez-en davantage, notamment sur la gestion des données de votre compte Firefox ou nos pratiques en matière de données pour les [sites Web et le courriel](https://www.mozilla.org/privacy/websites/). Vous pouvez également lire les politiques de confidentialité pour nos services associés aux comptes Firefox, à savoir : 
 
-* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
+* [Firefox Lockwise](https://support.mozilla.org/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)

--- a/firefox_privacy_notice/fr.md
+++ b/firefox_privacy_notice/fr.md
@@ -110,7 +110,7 @@ __Suggestions de recherche__ : Firefox envoie par défaut les requêtes de rech
 
 Lisez la documentation complète ou apprenez-en davantage, notamment sur la gestion des données de votre compte Firefox ou nos pratiques en matière de données pour les [sites Web et le courriel](https://www.mozilla.org/privacy/websites/). Vous pouvez également lire les politiques de confidentialité pour nos services associés aux comptes Firefox, à savoir : 
 
-* [Firefox Lockwise](https://lockbox.firefox.com/privacy.html)
+* [Firefox Lockwise](https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy)
 * [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
 * [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
 * [Firefox Send](http://send.firefox.com/legal)


### PR DESCRIPTION
We are updating all the links that point to lockwise.firefox.com to the correct content links. Also all instances of Lockbox have been changed to Lockwise to indicate the correct product name.

https://lockwise.firefox.com/ -> https://mozilla.org/firefox/lockwise
https://lockwise.firefox.com/privacy.html -> https://support.mozilla.org/kb/firefox-lockwise-and-privacy

Here is the issue I'm working on: https://github.com/mozilla/bedrock/issues/7628
