### PR TITLE
Thunderbird - Updating to inlcude Mailfence

### DIFF
--- a/en/thunderbird_privacy_policy.md
+++ b/en/thunderbird_privacy_policy.md
@@ -1,7 +1,7 @@
 # Thunderbird Privacy Notice
 
-August 31, 2020
-{: datetime="2020-08-31" }
+March 16, 2021
+{: datetime="2020-03-16" }
 
 The Thunderbird application allows users to privately integrate and manage their online communications.
 
@@ -67,4 +67,4 @@ __DNS servers, Standard Autoconfiguration URIs, and Mozilla's Configuration Data
 
 __Amazon Web Services__: Thunderbird uses Amazon Web Services (AWS) to host its servers and as a content delivery network. Your device’s IP address is collected as part of AWS’s server logs.
 
-__Gandi.net__: Thunderbird has partnered with Gandi.net to allow you to create a new email address through Thunderbird. If you choose to use this feature, your email address search terms are sent to Gandi.net to return available addresses. In addition, your country location is also shared with Gandi.net to provide the correct prices. You can learn more about Gandi.net’s data practices by reading their [Privacy Policy](https://contract.gandi.net/v5/contracts/14420/Privacy_Policy_US_2.0_en.pdf).
+__Email address providers__: Thunderbird has partnered with Gandi.net and Mailfence to allow you to create a new email address through Thunderbird. If you choose to use this feature, your email address search terms are sent to Gandi.net and Mailfence to return available addresses. In addition, your country location is also shared to provide the correct prices. You can learn more about [Gandi.net’s](https://contract.gandi.net/v5/contracts/14420/Privacy_Policy_US_2.0_en.pdf) and [Mailfence’s](https://mailfence.com/en/privacy.jsp) data practices by reading their privacy notices.

--- a/en/websites_privacy_notice.md
+++ b/en/websites_privacy_notice.md
@@ -1,7 +1,7 @@
 # Websites, Communications & Cookies Privacy Notice
 
-January 8, 2021
-{: datetime="2020-01-08" }
+March 8, 2021
+{: datetime="2020-03-08" }
 
 We care about your privacy. When Mozilla (that's us) collects information about you, our [Mozilla Privacy Policy](https://www.mozilla.org/privacy/) describes how we handle that information.
 
@@ -72,6 +72,6 @@ Some Mozilla websites allow you to make purchases (such as apps or gear), contri
 
 * **Payment Processing**: Except for payments made by check, money order, and direct debit, and wire transfers, Mozilla does not receive any financial information, which is transmitted from you to the named third party vendor for processing (e.g., Braintree, PayPal, Bitpay, Stripe).
 
-* **Personal Data**: We may also receive your name, mailing address, and/or email address. This data is used for fraud detection and record-keeping. We use [SalesForce Marketing Cloud](https://www.marketingcloud.com/privacy-policy/website-privacy-statement/) to email receipts and store records, which are retained for four years from the date of last payment. 
+* **Personal Data**: We may also receive your name, mailing address, and/or email address. This data is used for fraud detection and record-keeping. We use [Acoustic](https://acoustic.com/privacy-notice/) to email receipts and store records, which are retained for four years from the date of last payment. 
 
 * **Third Party Data**: We use [WealthEngine](https://www.wealthengine.com/wealthengine-inc-privacy-policy/) to improve our fundraising efforts to keep the internet healthy, open, and accessible for all. Donors can [opt-out](https://app.onetrust.com/app/#/webform/4ba08202-2ede-4934-a89e-f0b0870f95f0) of Mozilla’s use.


### PR DESCRIPTION
Thunderbird is adding Mailfence as an email address provider today (in addition to Gandi.net). Updating the privacy notice to reflect this change.