### PR TITLE
Removal of Premium in Nov 11 launch

### DIFF
--- a/de/firefox_relay_privacy_notice.md
+++ b/de/firefox_relay_privacy_notice.md
@@ -5,23 +5,21 @@
 
 Mit Firefox Relay können Sie Ihre primäre E-Mail-Adresse vor Onlinediensten schützen, indem Sie eindeutige, aber zufällige E-Mail-Adressen („Aliase“) erstellen. In diesem Datenschutzhinweis wird erläutert, welche Daten Firefox Relay teilt und warum das so ist. Wir halten uns auch an die in der [Mozilla-Datenschutzerklärung](https://www.mozilla.org/privacy/) umrissenen Praktiken in Bezug auf den Empfang, den Umgang mit und das Teilen von Informationen.
 
-### Von uns erfasste Informationen 
+### Von uns erfasste Informationen
 
 __Firefox-Kontoinformationen.__ Für diesen Dienst ist ein [Firefox-Konto](https://www.mozilla.org/privacy/firefox/#firefox-accounts-join-firefox) erforderlich. Hierüber übermitteln Sie Mozilla Ihre E-Mail-Adresse, Ihr Gebietsschema und Ihre IP-Adresse. Mozilla speichert eine Kopie Ihrer Kontoinformationen, um den Dienst zu erbringen, und insbesondere, um Ihre primäre E-Mail-Adresse mit Ihrer oder Ihren Alias-E-Mail-Adressen zu verknüpfen.
 
 __E-Mail-Nachrichten.__ Zum Senden und Weiterleiten Ihrer E-Mail-Nachrichten über Ihre Alias-E-Mail-Adresse(n) an Ihre Haupt-E-Mail-Adresse verarbeitet Firefox Relay Ihre E-Mail-Nachrichten. Wir lesen und speichern Ihre Nachrichten nicht. Sollte eine E-Mail nicht zugestellt werden können, bewahren wir sie auf unseren Servern auf und löschen sie nach der Zustellung. (Keinesfalls jedoch wird eine E-Mail länger als drei Tage von uns aufbewahrt.)
 
-__Wie Aliase verwendet werden können__: Wenn Sie einen eigenen Alias erstellen, speichert Mozilla diesen, um E-Mails an ihn weiterzuleiten. Mozilla speichert ferner die Website, auf der Sie den Alias erstellt haben, die Websites, auf denen Sie den Alias anschließend verwenden, und alle mit dem Alias verbundenen Labels, um sicherzustellen, dass Ihre Aliase leicht zu finden sind, wenn Sie sie verwenden möchten. [Hier erfahren Sie, wie Sie diese Funktionen aktivieren und deaktivieren können.](https://relay.firefox.com/faq)
+__Wie Aliase verwendet werden können__: Mozilla speichert ferner die Website, auf der Sie den Alias erstellt haben, die Websites, auf denen Sie den Alias anschließend verwenden, und alle mit dem Alias verbundenen Labels, um sicherzustellen, dass Ihre Aliase leicht zu finden sind, wenn Sie sie verwenden möchten. [Hier erfahren Sie, wie Sie diese Funktionen aktivieren und deaktivieren können.](https://relay.firefox.com/faq)
 
 __Interaktionsdaten.__ Mozilla empfängt Daten aus Interaktionen mit Firefox Relay, z. B. wenn Sie auf die Schaltflächen „Registrieren“ oder „Zu Firefox hinzufügen“ klicken oder eine Alias-E-Mail-Adresse erstellen, deaktivieren oder löschen.
 
 __Technische Daten.__ Mozilla empfängt von Firefox Relay grundlegende Informationen zu Ihrem Gerät und Ihrem Browser, einschließlich Browserversion, Sprache, Gerätebetriebssystem und Hardwarekonfiguration.
 
-__Informationen zur Zahlung__: Wenn Sie Firefox Relay Premium abonnieren, bezahlen Sie über einen der folgenden externen Zahlungsanbieter: Stripe oder PayPal. Mozilla erhält bestimmte Informationen zu Ihrem Konto, darunter die Rechnungsadresse und die letzten vier Ziffern der von Ihnen gewählten Zahlungsweise, und zum Status des Abonnements Ihres Kontos. Die vollständigen Zahlungsdaten werden von Mozilla nicht gespeichert.
-
 Lesen Sie die Telemetriedokumentation für [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). Sie können die Erfassung von Telemetriedaten ablehnen, indem Sie die Funktion [Do Not Track (DNT)](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) in Ihrem Browser aktivieren.  
 
-### Von uns geteilte Informationen 
+### Von uns geteilte Informationen
 
 Firefox Relay gibt Informationen an Dritte weiter, um den Dienst für Sie bereitzustellen. Mozilla hat mit dem betreffenden Anbieter eine Vereinbarung geschlossen, die ihn verpflichtet, Ihre Daten zu schützen. Wir nehmen die Leistungen des folgenden Anbieters für die Unterstützung von Firefox Relay in Anspruch:
 

--- a/es-ES/firefox_relay_privacy_notice.md
+++ b/es-ES/firefox_relay_privacy_notice.md
@@ -11,13 +11,11 @@ __Información de la cuenta de Firefox.__ Este servicio requiere una [cuenta de 
 
 __Mensajes de correo electrónico.__ Firefox Relay procesa sus mensajes de correo electrónico con el fin de enviar y reenviar sus mensajes de correo electrónico desde sus direcciones de correo electrónico alias a su dirección de correo electrónico principal. No leemos ni guardamos ninguno de sus mensajes. Si por algún motivo no podemos entregarle un mensaje de correo electrónico, lo guardamos temporalmente en nuestros servidores y lo eliminamos una vez que lo hayamos entregado (en ningún caso se conservará durante más de tres días).
 
-__Alias y dónde los utiliza.__ Si usted crea un alias personalizado, Mozilla lo guarda para poder reenviar los mensajes de correo electrónico a dicha dirección. Mozilla guarda el sitio en el que creó el alias, los sitios en los que posteriormente usa el alias y cualquier etiqueta asociada al alias con el fin de garantizar que pueda acceder fácilmente a dicho alias cuando quiera usarlo. Para aprender cómo activar y desactivar estas funciones [haga clic aquí](https://relay.firefox.com/faq).
+__Alias y dónde los utiliza.__ Mozilla guarda el sitio en el que creó el alias, los sitios en los que posteriormente usa el alias y cualquier etiqueta asociada al alias con el fin de garantizar que pueda acceder fácilmente a dicho alias cuando quiera usarlo. Para aprender cómo activar y desactivar estas funciones [haga clic aquí](https://relay.firefox.com/faq).
 
 __Datos de interacción.__ Mozilla recibe datos sobre su interacción con Firefox Relay, tales como datos sobre cuando hace clic en los botones «suscribirse» y «añadir a Firefox» y cuando crea, desactiva o elimina un alias de correo electrónico.
 
 __Datos técnicos.__ Mozilla recibe información básica de Firefox Relay sobre su dispositivo y navegador, como por ejemplo, la versión del navegador, idioma, sistema operativo del dispositivo y configuración del hardware.
-
-__Información de pago.__ Si se suscribe a Firefox Relay Premium, tendrá que realizar el pago a través de uno de los siguientes proveedores de terceros: Stripe o PayPal. Mozilla recibirá información sobre su cuenta (p. ej., su dirección de facturación y los últimos cuatro dígitos de su método de pago) y el estado de la suscripción de su cuenta. Mozilla no guarda todos sus datos de pago.
 
 Lea los documentos telemétricos de [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). Tiene la opción de desactivar la recopilación de datos telemétricos activando la función [No rastrear](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) en su navegador.  
 

--- a/fr/firefox_relay_privacy_notice.md
+++ b/fr/firefox_relay_privacy_notice.md
@@ -5,23 +5,21 @@
 
 Firefox Relay vous permet de protéger votre adresse email principale des services en ligne en créant des adresses uniques et aléatoires (*alias*). Cette politique de confidentialité explique quelles données Firefox Relay partage, et dans quels buts. Nous adhérons en outre à la [Politique de confidentialité de Mozilla](https://www.mozilla.org/privacy/), qui explique comment nous recevons, traitons et partageons les informations.
 
-### Informations que nous collectons 
+### Informations que nous collectons
 
 __Informations de compte Firefox.__ Ce service nécessite un compte [compte Firefox](https://www.mozilla.org/privacy/firefox/#firefox-accounts-join-firefox), qui envoie à Mozilla votre adresse e-mail, langue et adresse IP. Mozilla conserve une copie des informations de votre compte pour fournir le Service, en particulier pour associer votre adresse email principale à votre ou vos alias.
 
 __Messages email.__ Pour envoyer et transférer vos messages email depuis votre ou vos alias d’adresse(s) email vers votre adresse email principale, Firefox Relay doit traiter vos messages email. Nous ne lisons ni ne stockons le contenu de vos messages. Si un email ne peut pas vous être acheminé, nous le conservons sur nos serveurs et le supprimons après avoir été acheminé (dans tous les cas, nous ne le conservons pas plus de trois jours).
 
-__Comment utiliser les alias__ : Lorsque vous créez un alias personnalisé, Mozilla le stocke pour pouvoir lui transférer des emails. Mozilla stocke le site sur lequel vous avez créé l’alias, les sites sur lesquels vous allez ensuite utiliser l’alias, et tous libellés associés à l’alias, afin de garantir que vos alias soient faciles à trouver lorsque vous êtes prêt à les utiliser. Apprenez à activer et désactiver ces fonctionnalités [ici](https://relay.firefox.com/faq).
+__Comment utiliser les alias__ : Mozilla stocke le site sur lequel vous avez créé l’alias, les sites sur lesquels vous allez ensuite utiliser l’alias, et tous libellés associés à l’alias, afin de garantir que vos alias soient faciles à trouver lorsque vous êtes prêt à les utiliser. Apprenez à activer et désactiver ces fonctionnalités [ici](https://relay.firefox.com/faq).
 
 __Données d’interaction.__ Mozilla reçoit des données provenant d’interactions avec Firefox Relay, par exemple lorsque vous cliquez sur les boutons « S’abonner » ou « Ajouter à Firefox », et lorsque vous créez, désactivez ou supprimez un alias.
 
 __Données techniques.__ Mozilla reçoit des informations de base depuis Firefox Relay concernant votre appareil et navigateur, notamment la version et la langue du navigateur, le système d’exploitation de l’appareil et sa configuration matérielle.
 
-__Informations de paiement__ : Si vous vous abonnez à Firefox Relay Premium, vous enverrez un paiement par le biais de l’un de nos fournisseurs de paiement tiers : Stripe ou PayPal. Mozilla reçoit un enregistrement de votre compte (comprenant votre adresse de facturation et les quatre derniers chiffres de votre mode de paiement) et le statut de l’abonnement de votre compte. Mozilla ne stocke pas tous les détails de vos paiements.
-
 Lisez la documentation de télémesure concernant [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). Vous pouvez annuler la collecte de données télémétriques en activant la fonctionnalité [Ne pas me suivre](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) dans votre navigateur.  
 
-### Informations que nous partageons 
+### Informations que nous partageons
 
 Firefox Relay partage des données avec certaines sociétés tierces afin de vous fournir le Service. Mozilla a conclu un accord avec cette société, obligeant cette dernière à protéger vos informations. Voici les sociétés que nous utilisons pour supporter Firefox Relay :
 

--- a/it/firefox_relay_privacy_notice.md
+++ b/it/firefox_relay_privacy_notice.md
@@ -5,23 +5,21 @@
 
 Firefox Relay ti consente di mantenere il tuo indirizzo email principale sicuro e riservato quando utilizzi servizi online mediante la creazione di indirizzi email univoci e casuali (*alias*). Questa informativa sulla privacy spiega quali dati vengono raccolti da Firefox Relay, come vengono condivisi e perché. Per quanto riguarda il modo in cui riceviamo, gestiamo e condividiamo le informazioni, puoi anche fare riferimento all'[Informativa sulla privacy di Mozilla](https://www.mozilla.org/privacy/).
 
-### Informazioni che raccogliamo 
+### Informazioni che raccogliamo
 
 __Informazioni sull'account Firefox.__ Questo servizio richiede un [account Firefox](https://www.mozilla.org/privacy/firefox/#firefox-accounts-join-firefox), che invia a Mozilla il tuo indirizzo email, le impostazioni locali e l'indirizzo IP. Mozilla conserva una copia delle informazioni del tuo account per fornire il servizio, in particolare per associare il tuo indirizzo email principale al/i tuo/i indirizzo/i email alias.
 
 __Messaggi email.__ Per inviare e inoltrare i tuoi messaggi email dal/i tuo/i indirizzo/i email alias al tuo indirizzo email principale, Firefox Relay elabora i tuoi messaggi. Il contenuto dei messaggi non viene né letto né memorizzato. Nel caso un'email non possa essere consegnata, verrà temporaneamente memorizzata nei nostri server ed eliminata dopo la consegna (in nessun caso verrà conservata per più di tre giorni).
 
-__Alias e dove utilizzarli__: Se crei un alias personalizzato, Mozilla lo memorizza per inoltrarvi le email. Mozilla memorizza il sito dove hai creato l'alias, i siti dove successivamente lo utilizzi e tutte le etichette associate all'alias, in modo che sia sempre facilmente reperibile quando dovrai utilizzarlo. Scopri come abilitare e disabilitare queste funzioni [qui](https://relay.firefox.com/faq).
+__Alias e dove utilizzarli__: Mozilla memorizza il sito dove hai creato l'alias, i siti dove successivamente lo utilizzi e tutte le etichette associate all'alias, in modo che sia sempre facilmente reperibile quando dovrai utilizzarlo. Scopri come abilitare e disabilitare queste funzioni [qui](https://relay.firefox.com/faq).
 
 __Dati relativi alle interazioni.__ Mozilla riceve dati dalle tue interazioni con Firefox Relay, ad esempio quando fai clic sui pulsanti "Registrati" o "Aggiungi a Firefox" e quando crei, disabiliti o elimini un indirizzo email alias.
 
 __Dati tecnici.__ Mozilla riceve informazioni di base da Firefox Relay sul tuo dispositivo e sul tuo browser, inclusa la versione del browser, la lingua, il sistema operativo del dispositivo e la sua configurazione hardware.
 
-__Informazioni di pagamento__: Se ti iscrivi a Firefox Relay Premium, il tuo addebito sarà gestito tramite uno dei nostri fornitori terzi di servizi di pagamento: Stripe o PayPal. Mozilla riceve un record del tuo account (che include l'indirizzo di fatturazione e le ultime quattro cifre del tuo metodo di pagamento) e lo stato del tuo abbonamento. Mozilla non memorizza i dettagli completi del pagamento.
-
 Leggi la documentazione relativa alla telemetria per [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). Puoi rifiutare la raccolta di dati di telemetria attivando la [Protezione antitracciamento](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) del tuo browser.  
 
-### Informazioni che condividiamo 
+### Informazioni che condividiamo
 
 Firefox Relay condivide informazioni con un'azienda di terze parti per fornirti il servizio. Mozilla ha stipulato accordi con questa azienda affinché i tuoi dati vengano protetti. Ecco chi utilizziamo per supportare Firefox Relay:
 

--- a/ms/firefox_relay_privacy_notice.md
+++ b/ms/firefox_relay_privacy_notice.md
@@ -11,13 +11,11 @@ __Maklumat Akaun Firefox.__ Perkhidmatan ini memerlukan [Akaun Firefox](https://
 
 __Mesej e-mel.__ Untuk mengirim dan menghantar mesej e-mel anda dari alamat e-mel alias anda ke alamat e-mel utama anda, Firefox Relay memproses mesej e-mel anda. Kami tidak membaca atau menyimpan apa-apa mesej anda. Sekiranya e-mel tidak dapat dihantar kepada anda, kami akan menyimpannya pada pelayan kami dan akan menghapuskannya selepas e-mel ini dihantar (kami tidak akan menyimpannya lebih daripada tiga hari).
 
-__Alias dan di mana anda menggunakannya__: Jika anda mencipta alias tersuai, Mozilla menyimpannya bagi menghantar e-mel ke alamat ini. Mozilla menyimpan laman di mana anda mencipta alias, laman di mana anda kemudiannya menggunakan alias dan apa-apa label yang dikaitkan dengan alias bagi memastikan alias anda mudah ditemui apabila anda bersedia untuk menggunakannya. Pelajari cara untuk mengupayakan dan menyahupayakan ciri ini [di sini](https://relay.firefox.com/faq).
+__Alias dan di mana anda menggunakannya__: Mozilla menyimpan laman di mana anda mencipta alias, laman di mana anda kemudiannya menggunakan alias dan apa-apa label yang dikaitkan dengan alias bagi memastikan alias anda mudah ditemui apabila anda bersedia untuk menggunakannya. Pelajari cara untuk mengupayakan dan menyahupayakan ciri ini [di sini](https://relay.firefox.com/faq).
 
 __Data interaksi.__ Mozilla menerima data daripada interaksi dengan Firefox Relay, seperti semasa anda klik pada butang “daftar” atau “tambah pada Firefox”, dan semasa anda mencipta, menyahupayakan atau menghapuskan alamat e-mel alias.
 
 __Data teknikal.__ Mozilla menerima maklumat asas dari Firefox Relay tentang peranti dan penyemak imbas anda, termasuk versi penyemak imbas, bahasa, sistem operasi peranti dan konfigurasi perkakasan.
-
-__Maklumat pembayaran__: Jika anda melanggan Firefox Relay Premium, anda akan menghantar bayaran melalui salah satu penyedia pembayaran pihak ketiga kami: Stripe atau PayPal. Mozilla menerima rekod akaun anda (termasuk alamat bil dan empat digit terakhir kaedah pembayaran anda) dan status langganan akaun anda. Mozilla tidak menyimpan butiran lengkap pembayaran anda.
 
 Baca dokumentasi telemetri untuk [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). Anda boleh memilih untuk keluar daripada kutipan telemetri dengan memasang ciri [Do Not Track (DNT)](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) pada penyemak imbas anda.  
 

--- a/nl/firefox_relay_privacy_notice.md
+++ b/nl/firefox_relay_privacy_notice.md
@@ -5,19 +5,17 @@
 
 Met Firefox Relay (de Service) kunt u uw primaire e-mailadres veilig en privé houden voor online services. U maakt hiertoe willekeurige aliase-mailaddressen. Deze privacyverklaring gaat in op welke gegevens Firefox Relay verzamelt en deelt en waarom. We houden ons daarnaast aan het [Privacybeleid van Mozilla](https://www.mozilla.org/privacy/) ten aanzien van hoe we informatie ontvangen, verzamelen en delen.
 
-### Informatie die we verzamelen 
+### Informatie die we verzamelen
 
 __Firefox-accountinformatie.__ Deze service vereist een [Firefox-account](https://www.mozilla.org/privacy/firefox/#firefox-accounts-join-firefox) dat uw e-mailadres, landinstellingen en IP-adres naar Mozilla verzendt. Mozilla bewaart een kopie van uw accountinformatie voor het verzorgen van de service en in het bijzonder om uw primaire e-mailadres te koppelen aan uw alias emailadres(sen).
 
 __E-mailberichten.__ Als u uw e-mailberichten verzendt en doorstuurt vanaf uw alias-e-mailadressen naar uw primaire e-mailadres, verwerkt Firefox Relay uw e-mailberichten. We lezen en bewaren uw berichten nooit. In het geval dat een e-mail niet aan u kan worden bezorgd, bewaren we deze op onze servers en verwijderen we deze nadat de e-mail is bezorgd (in geen enkel geval bewaren we het bericht langer dan drie dagen).
 
-__Aliassen en waar u deze gebruikt__: Als u een aangepaste alias hebt gemaakt, slaat Mozilla deze op, zodat e-mail naar deze alias kan worden doorgestuurd. Mozilla registreert de site waarop u de alias hebt gemaakt, sites waarop u vervolgens de alias gebruikt en eventuele labels bij de alias om ervoor te zorgen dat uw aliassen eenvoudig kunnen worden gevonden wanneer u klaar bent om deze te gebruiken. [Hier](https://relay.firefox.com/faq) vindt u meer informatie over hoe u deze functies kunt inschakelen en uitschakelen.
+__Aliassen en waar u deze gebruikt__: Mozilla registreert de site waarop u de alias hebt gemaakt, sites waarop u vervolgens de alias gebruikt en eventuele labels bij de alias om ervoor te zorgen dat uw aliassen eenvoudig kunnen worden gevonden wanneer u klaar bent om deze te gebruiken. [Hier](https://relay.firefox.com/faq) vindt u meer informatie over hoe u deze functies kunt inschakelen en uitschakelen.
 
 __Interactiegegevens.__ Mozilla ontvangt gegevens over de interactie met Firefox Relay, zoals wanneer u op de knoppen voor registreren of toevoegen aan Firefox klikt en wanneer u een aliase-mailadres maakt, uitschakelt of verwijdert.
 
 __Technische gegevens.__ Mozilla ontvangt basisinformatie van Firefox Relay over uw apparaat en browser, waaronder de browserversie, de taal, het besturingssysteem van het apparaat en de hardwareconfiguratie.
-
-__Betalingsinformatie__: Wanneer u zich abonneert op Firefox Relay Premium, doet u een betaling via een van onze externe betalingsproviders: Stripe of PayPal. Mozilla ontvangt een registratie van uw account (met onder meer uw factureringsadres en de laatste vier cijfers van uw betalingsmethode) en de status van het abonnement van uw account. Uw volledige betalingsgegevens worden niet opgeslagen door Mozilla.
 
 Lees de telemetriedocumentatie voor [Firefox Relay](https://github.com/mozilla/fx-private-relay/blob/master/METRICS.md?). U kunt zich uitschrijven voor telemetrieverzameling door de functie [Do Not Track (DNT)](https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature) in uw browser in te schakelen.  
 


### PR DESCRIPTION
Removal of Premium mentions according to the changes in the English doc: https://github.com/mozilla/legal-docs/commit/e4b085475cabdf3765b692858a59fb8e5c02231f#diff-66fd0fd01228e21a6f16d9c2825755dcbcd78c4a3861625ad2648b6f0d5209ca for Nov 11 launch.