### PR TITLE
Fix typo in Firefox PN - zh-CN

### DIFF
--- a/zh-CN/firefox_privacy_notice.md
+++ b/zh-CN/firefox_privacy_notice.md
@@ -61,7 +61,7 @@ Mozilla 和 Pocket 会收集有关您查看和点击的建议内容的汇总数�
 
 **证书颁发机构的网页和技术数据**：当您访问安全网站（通常以“HTTPS”开头的 URL 进行标识）时，Firefox 会验证该网站的[证书](https://support.mozilla.org/kb/secure-website-certificate)。该过程可能涉及 Firefox 向该网站所标识的证书颁发机构发送有关该网站的特定信息。选择退出会增加您的隐私信息被拦截的风险。[了解更多信息](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab)。
 
-### 奔溃报告 {: #crash-reporter }
+### 崩溃报告 {: #crash-reporter }
 默认情况下，在桌面版 Firefox 上，我们将要求您与 Mozilla 共享报告并提供更详细的崩溃信息，但您随时可以选择拒绝。
 
 * __敏感数据__：崩溃报告包括 Firefox 发生崩溃时内存内容的“转储文件”，其中可能包含可识别您身份或在其他方面较为敏感的数据。


### PR DESCRIPTION
Fix typo per bug https://bugzilla.mozilla.org/show_bug.cgi?id=1744486

Change `奔溃` to `崩溃`