### PR TITLE
Simplify push to prod instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,17 @@ File a pull request that updates your locale's markdown file to match the `en-US
 
 For www.mozilla.org, the process is as follows:
 
-1. Look at the documents to be published on the staging site and make sure they look right:
+1. Check the documents to be published on the staging site and make sure they look right:
     * https://www-dev.allizom.org/privacy/
     * https://www-dev.allizom.org/about/legal/
-2. Go to the "Actions" tab in the repo. It should be next to "Issues" and "Pull requests" near the top of the page.
-3. On the left side under "Workflows" click "Publish Documents to Production". ![Screen Shot 2022-03-25 at 09 35 53](https://user-images.githubusercontent.com/19176817/160134801-1cacc2fa-ba16-4c11-a0fd-1dc9ac6b7240.png)
-4. There will be a banner that says "This workflow has a workflow_dispatch event trigger." and next to it on the right a button that says "Run Workflow". Click this button. ![Screen Shot 2022-03-25 at 09 36 14](https://user-images.githubusercontent.com/19176817/160134925-05b56aec-4c0a-4104-bc1e-e57c9cb812d0.png)
-5. A form should now be open with a field for a list of "files to publish". The default value is "ALL". If you change nothing and click the "Run workflow" button all changes to all files will be included in the pull request that is opened. If that is not what you want you can enter file names in this field. It can be a comma separated list of filenames (e.g. `mdn_plus_terms.md, mdn_plus_privacy.md`), or you can use the `*` character to include all files with a prefix (e.g. `mdn_plus_*`).
-6. Click "Run workflow"
-7. It may take a few seconds, but the running workflow will show up on the screen with an animated progress indicator. ![Screen Shot 2022-03-25 at 09 38 40](https://user-images.githubusercontent.com/19176817/160135112-29db7e7c-7589-4055-a56a-577ad3527344.png)
-8. Once this is finished, and everything was successful, a new Pull Request should have been opened with all of the requested changes.
-9. Review this Pull Request. It will have the title "[prod] Publish document updates".
-10. Once you are satisfied that the correct changes have been included, merge the Pull Request and the changes will be published to the website within a few minutes.
+2. [Open this link](https://github.com/mozilla/legal-docs/actions/workflows/prod_push.yml) to access the _Actions_ tab in the repo on the `Publish Documents to Production` workflow. ![Screen Shot 2022-03-25 at 09 35 53](https://user-images.githubusercontent.com/19176817/160134801-1cacc2fa-ba16-4c11-a0fd-1dc9ac6b7240.png)
+3. There will be a banner that says "This workflow has a workflow_dispatch event trigger." and, next to it on the right, a button that says `Run Workflow`. Click this button. ![Screen Shot 2022-03-25 at 09 36 14](https://user-images.githubusercontent.com/19176817/160134925-05b56aec-4c0a-4104-bc1e-e57c9cb812d0.png)
+4. A form should now open with a field for a list of "files to publish". The default value is `ALL`. If you change nothing and click the `Run workflow` button, all changes to all files will be included in the pull request that is opened. If that is not what you want, you can enter file names in this field. It can be a comma separated list of filenames (e.g. `mdn_plus_terms.md, mdn_plus_privacy.md`), or you can use the `*` character to include all files with a prefix (e.g. `mdn_plus_*`).
+5. Click `Run workflow`.
+6. It may take a few seconds, but the running workflow will show up on the screen with an animated progress indicator. ![Screen Shot 2022-03-25 at 09 38 40](https://user-images.githubusercontent.com/19176817/160135112-29db7e7c-7589-4055-a56a-577ad3527344.png)
+7. Once this is finished, and everything was successful, a new [Pull Request](https://github.com/mozilla/legal-docs/pulls?q=is%3Aopen+is%3Apr+label%3Aprod) should have been opened with all of the requested changes.
+8. Review this Pull Request. It will have the title `[prod] Publish document updates`.
+9. Once you are satisfied that the correct changes have been included, merge the Pull Request and the changes will be published to the website within a few minutes.
 
 
 ## URL Inventory


### PR DESCRIPTION
The only significant change is providing a link to access the workflow, instead of instructions. The rest is small fixes (mostly using backticks instead of quotes).

Sadly, GitHub's diff is not very helpful here.