### PR TITLE
Update formatting of Hubs privacy doc to be simpler Markdown

### DIFF
--- a/en/mozilla_hubs_privacy_notice.md
+++ b/en/mozilla_hubs_privacy_notice.md
@@ -4,7 +4,7 @@
 Aug 24, 2021
 {: datetime="2021-08-04" }
 
-In this Privacy Notice, we explain what data [Hubs](https://hubs.mozilla.com) and [Spoke](https://hubs.mozilla.com/spoke) collect and share, and why. We also adhere to the practices outlined in the Mozilla [Privacy Policy](https://www.mozilla.org/en-US/privacy/) for how we receive, handle, and share information.
+In this Privacy Notice, we explain what data [Hubs](https://hubs.mozilla.com) and [Spoke](https://hubs.mozilla.com/spoke) collect and share, and why. We also adhere to the practices outlined in the Mozilla [Privacy Policy](https://www.mozilla.org/privacy/) for how we receive, handle, and share information.
 
 ## Information We Collect and Share When You’re In a Room
 

--- a/en/mozilla_hubs_privacy_notice.md
+++ b/en/mozilla_hubs_privacy_notice.md
@@ -9,60 +9,44 @@ In this Privacy Notice, we explain what data may be accessible to Mozilla or oth
 
 ## Things you should know:
 
-<details open>
-  <summary>
-    <strong>Your presence and communications are sent to Mozilla and other Room participants.</strong>
-  </summary>
+### Your presence and communications are sent to Mozilla and other Room participants. {: #PresenceAndCommunicationsAreSent }
 
-- **Avatar data**: We receive and send to others in the Room the name and likeness of your Avatar, its position in the Room, and your interactions with objects in the Room. 
+- **Avatar data**: We receive and send to others in the Room the name and likeness of your Avatar, its position in the Room, and your interactions with objects in the Room.
   - **Custom Avatars**: You may create a custom avatar. If you create an account, Mozilla will store your custom avatar, associated with your account.
-  - **Stock Avatars**: If you choose one of the regular avatars, you may login to store information about your avatar with Mozilla. You can optionally store information about your Avatar in your browser’s local storage if you do not log in to your account.  
-- **Room data**: Rooms are publicly accessible to anyone with the URL. Mozilla receives data about the virtual objects and Avatars in a Room and shares that data with others in the Room.     
+  - **Stock Avatars**: If you choose one of the regular avatars, you may login to store information about your avatar with Mozilla. You can optionally store information about your Avatar in your browser’s local storage if you do not log in to your account.
+- **Room data**: Rooms are publicly accessible to anyone with the URL. Mozilla receives data about the virtual objects and Avatars in a Room and shares that data with others in the Room.
 - **Voice data**: If your microphone is on, Mozilla receives and sends audio to other users in the Room. Mozilla does not record or store the audio.  *Be aware that once you agree to let Hubs use your microphone, it will stay on as long as you remain in a Hubs room, unless you turn it off.*
 - **In-Room Photos and Video**: You can use the camera tool to take photos and video unless the room owner has disabled this feature. The camera tool displays a red icon during filming. Your avatar will also indicate to others with a red icon that you are filming and capturing audio from enabled microphones in the room.
-  - Data retention: If you take a photo or video, the file is stored locally on your device and uploaded to Mozilla’s servers so that it can be shared within the room. Pinned files are stored permanently in your room unless you remove it. Unpinned files are deleted from Mozilla’s servers after 72 hours. 
+  - Data retention: If you take a photo or video, the file is stored locally on your device and uploaded to Mozilla’s servers so that it can be shared within the room. Pinned files are stored permanently in your room unless you remove it. Unpinned files are deleted from Mozilla’s servers after 72 hours.
 - **Third-Party Communications Services**: Hubs allows you to connect some third-party services to a Hubs room.
   - **Twitter**: Logging into your Twitter account from Hubs allows you to tweet and share 2D images. Any content you tweet will be shared with Twitter and published publicly on the Twitter platform. You can see Twitter’s [Privacy Policy](https://twitter.com/en/privacy) for more information.
   - **Discord**: Hubs allows you to connect Discord to a Hubs room. When someone has connected Discord to a Hubs room, we store access tokens and the server and channel IDs that have been connected. We will synchronize chat messages, room changes, 2D and 3D objects you create, and whether a user joins or leaves with the connected Discord channel, but do not log any of these synchronized messages. For diagnostics, we log aggregated counts such as the number of messages and users who have joined relevant channels. You can see [Discord’s Privacy Policy](https://discordapp.com/privacy) for more information.
 
 - You can learn more by looking at the [code itself](https://github.com/mozilla/hubs) for Hubs. [Janus SFU](https://github.com/mozilla/janus-plugin-sfu), [Reticulum](https://github.com/mozilla/reticulum), [Hubs](https://github.com/mozilla/hubs), [Hubs-Ops](https://github.com/mozilla/hubs-ops), [Discord Bot](https://github.com/MozillaReality/hubs-discord-bot)
 
-</details>
-
-<details open>
-  <summary>
-    <strong>Mozilla receives data you create and share with Spoke and Hubs.</strong>
-  </summary>
+### Mozilla receives data you create and share with Spoke and Hubs. {: #MozillaReceivesDataYouCreateAndShare }
 
 - **Images, Video, and Objects**: Mozilla receives video and image file links to process and display them in the Hubs Room. Mozilla stores this data as long as you remain in the Room. If you pin a video, image, or object in the Room, Mozilla will store that information until the object or room is deleted.
-- **Scenes and Avatars You Share**: Mozilla receives 3D Room model links, 3D Avatar information, and the name of the Room or Avatar in order to process and display the Room or Avatar. Mozilla stores the name and the URL for the link you share so you and others with the link to the Room can use it again. 
-- **Search**: You can search for images, GIFs, and 3D Models to share in Hubs. We use third-party search providers. When you search, we will send your searches to these third parties, which have their own privacy policies. 
-  - Microsoft Bing Video & Image Search: https://privacy.microsoft.com/en-us/privacystatement
-  - Tenor: https://tenor.com/legal-privacy
-  - Sketchfab: https://sketchfab.com/privacy
-  - Google Poly & YouTube: https://policies.google.com/privacy
-  - Twitch: https://www.twitch.tv/p/legal/privacy-policy/
+- **Scenes and Avatars You Share**: Mozilla receives 3D Room model links, 3D Avatar information, and the name of the Room or Avatar in order to process and display the Room or Avatar. Mozilla stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
+- **Search**: You can search for images, GIFs, and 3D Models to share in Hubs. We use third-party search providers. When you search, we will send your searches to these third parties, which have their own privacy policies.
+  - Microsoft Bing Video & Image Search: <https://privacy.microsoft.com/en-us/privacystatement>
+  - Tenor: <https://tenor.com/legal-privacy>
+  - Sketchfab: <https://sketchfab.com/privacy>
+  - Google Poly & YouTube: <https://policies.google.com/privacy>
+  - Twitch: <https://www.twitch.tv/p/legal/privacy-policy/>
 
-<details open>
-  <summary>
-    <strong>Mozilla receives data when you create and publish Scenes with Spoke or create a custom Avatar.</strong>
-  </summary>
+### Mozilla receives data when you create and publish Scenes with Spoke or create a custom Avatar. {: #MozillaReceivesData2 }
 
-- **Scenes and Avatars You Create**: When you create a scene with Spoke or a custom avatar, Mozilla receives a copy of that scene or avatar. Mozilla stores that data in order to be able to process and display the scene or avatar through Hubs. 
-- **Publishing Your Scene or Avatar**: When you publish a scene or avatar to Hubs, Mozilla will ask for your email address to send you a link to verify your email. Mozilla will receive and store your email address to allow you to log in and view your 3D Room models and Avatars. Mozilla stores a hashed version of email addresses you use to publish a scene, so the stored versions are not available in readable form. 
+- **Scenes and Avatars You Create**: When you create a scene with Spoke or a custom avatar, Mozilla receives a copy of that scene or avatar. Mozilla stores that data in order to be able to process and display the scene or avatar through Hubs.
+- **Publishing Your Scene or Avatar**: When you publish a scene or avatar to Hubs, Mozilla will ask for your email address to send you a link to verify your email. Mozilla will receive and store your email address to allow you to log in and view your 3D Room models and Avatars. Mozilla stores a hashed version of email addresses you use to publish a scene, so the stored versions are not available in readable form.
 - **Remixing, Promotion, and Favorites**: When you publish a scene or avatar to Hubs, you have the option to “Allow Remixing with Creative Commons [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/)” or allow Mozilla to promote your scene or avatar. If you choose one or both of these options, Mozilla will share your scene or avatar publicly and you will have the option of including attribution information, which will also be publicly available. If you mark a Room or Avatar as a Favorite, Mozilla will store that information associated with your account.
 
-- You can learn more by looking at the [code itself](https://github.com/mozilla/spoke) for Spoke. 
-</details>
+- You can learn more by looking at the [code itself](https://github.com/mozilla/spoke) for Spoke.
 
-<details open>
-  <summary>
-    <strong>Mozilla receives technical and interaction data to improve performance and stability for Hubs.</strong>
-  </summary>
+### Mozilla receives technical and interaction data to improve performance and stability for Hubs.
 
-- **Account data**: You do not need to create an account to use Hubs. If you decide to create an account with your email address, we receive your email address to send you a login link, but stores only a hashed version of your email address. If you decide to use Discord to create your account, we receive the email address associated with your Discord account and your Discord avatar. 
+- **Account data**: You do not need to create an account to use Hubs. If you decide to create an account with your email address, we receive your email address to send you a login link, but stores only a hashed version of your email address. If you decide to use Discord to create your account, we receive the email address associated with your Discord account and your Discord avatar.
 - **Technical data**: We receive and store data about Room URLs and names; the type of device you use to interact with Hubs, as well as its operating system, language, the name and version of browser; and other data to load and operate the Room.
 - **Interaction data**: We receive data about your interactions with the Hubs service itself such as the number of Rooms created, messages sent through or to third-party services like Slack and Discord, the maximum number of users in a particular room at one same time, the start and end time of a user’s interaction with Hubs, the amount of time a user interacts with Hubs through Virtual Reality, the first time in a particular month or day that a user begins to use Hubs. Mozilla uses third party services to store and analyze these operational messages. We also also use Google Analytics, which places a cookie on your device, to obtain metrics on how users engage with our websites. This helps us to improve site content.
-- **Error Data**: In order to diagnose problems, Hubs sends Mozilla logs of error messages (which include the Room URL, response time for requests, the page you were on when you encountered the error, your operating system, browser information, and may include your IP address). 
+- **Error Data**: In order to diagnose problems, Hubs sends Mozilla logs of error messages (which include the Room URL, response time for requests, the page you were on when you encountered the error, your operating system, browser information, and may include your IP address).
 - You can learn more by looking at the [code itself](https://github.com/mozilla/hubs) for Hubs.  [Janus SFU](https://github.com/mozilla/janus-plugin-sfu), [Reticulum](https://github.com/mozilla/reticulum), [Hubs](https://github.com/mozilla/hubs), [Hubs-Ops](https://github.com/mozilla/hubs-ops), [Discord Bot](https://github.com/MozillaReality/hubs-discord-bot)
-</details>

--- a/en/mozilla_hubs_privacy_notice.md
+++ b/en/mozilla_hubs_privacy_notice.md
@@ -1,52 +1,67 @@
-# Privacy Notice for Hubs and Spoke
 
-Version 3.2.3, July 11, 2019
-{: datetime="2019-07-11" }
+# Hubs and Spoke Privacy Notice
 
-## At Mozilla (that’s us), we believe that privacy is fundamental to a healthy internet.
+Aug 24, 2021
+{: datetime="2021-08-04" }
 
-In this Privacy Notice, we explain what data may be accessible to Mozilla or others when you use [Hubs](https://hubs.mozilla.com) or [Spoke](https://hubs.mozilla.com/spoke). We also adhere to the practices outlined in the Mozilla [privacy policy](https://www.mozilla.org/privacy/) for how we receive, handle, and share information we collect from Hubs.
+In this Privacy Notice, we explain what data [Hubs](https://hubs.mozilla.com) and [Spoke](https://hubs.mozilla.com/spoke) collect and share, and why. We also adhere to the practices outlined in the Mozilla [Privacy Policy](https://www.mozilla.org/en-US/privacy/) for how we receive, handle, and share information.
 
-## Things you should know:
+## Information We Collect and Share When You’re In a Room
 
-### Your presence and communications are sent to Mozilla and other Room participants. {: #PresenceAndCommunicationsAreSent }
+### Information You Share With Us and Other Participants
 
-- **Avatar data**: We receive and send to others in the Room the name and likeness of your Avatar, its position in the Room, and your interactions with objects in the Room.
-  - **Custom Avatars**: You may create a custom avatar. If you create an account, Mozilla will store your custom avatar, associated with your account.
-  - **Stock Avatars**: If you choose one of the regular avatars, you may login to store information about your avatar with Mozilla. You can optionally store information about your Avatar in your browser’s local storage if you do not log in to your account.
-- **Room data**: Rooms are publicly accessible to anyone with the URL. Mozilla receives data about the virtual objects and Avatars in a Room and shares that data with others in the Room.
-- **Voice data**: If your microphone is on, Mozilla receives and sends audio to other users in the Room. Mozilla does not record or store the audio.  *Be aware that once you agree to let Hubs use your microphone, it will stay on as long as you remain in a Hubs room, unless you turn it off.*
-- **In-Room Photos and Video**: You can use the camera tool to take photos and video unless the room owner has disabled this feature. The camera tool displays a red icon during filming. Your avatar will also indicate to others with a red icon that you are filming and capturing audio from enabled microphones in the room.
-  - Data retention: If you take a photo or video, the file is stored locally on your device and uploaded to Mozilla’s servers so that it can be shared within the room. Pinned files are stored permanently in your room unless you remove it. Unpinned files are deleted from Mozilla’s servers after 72 hours.
-- **Third-Party Communications Services**: Hubs allows you to connect some third-party services to a Hubs room.
-  - **Twitter**: Logging into your Twitter account from Hubs allows you to tweet and share 2D images. Any content you tweet will be shared with Twitter and published publicly on the Twitter platform. You can see Twitter’s [Privacy Policy](https://twitter.com/en/privacy) for more information.
-  - **Discord**: Hubs allows you to connect Discord to a Hubs room. When someone has connected Discord to a Hubs room, we store access tokens and the server and channel IDs that have been connected. We will synchronize chat messages, room changes, 2D and 3D objects you create, and whether a user joins or leaves with the connected Discord channel, but do not log any of these synchronized messages. For diagnostics, we log aggregated counts such as the number of messages and users who have joined relevant channels. You can see [Discord’s Privacy Policy](https://discordapp.com/privacy) for more information.
+We need certain information to operate Hubs and Spoke. For example, we need information about your account in order to save your avatar. Here’s the information we may receive from you:
 
-- You can learn more by looking at the [code itself](https://github.com/mozilla/hubs) for Hubs. [Janus SFU](https://github.com/mozilla/janus-plugin-sfu), [Reticulum](https://github.com/mozilla/reticulum), [Hubs](https://github.com/mozilla/hubs), [Hubs-Ops](https://github.com/mozilla/hubs-ops), [Discord Bot](https://github.com/MozillaReality/hubs-discord-bot)
+**Account information**: You don’t need an account to use Hubs. However, certain features (like storing your avatar), require an account. You can create an account through Mozilla or through Discord. If you create an account with your email address, we store a hashed version of your email address. If you create an account through Discord, we receive the email address associated with your Discord account and your Discord avatar.
 
-### Mozilla receives data you create and share with Spoke and Hubs. {: #MozillaReceivesDataYouCreateAndShare }
+**Room Name and URL**: Rooms and room names are publicly accessible to anyone with the URL. Mozilla stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
 
-- **Images, Video, and Objects**: Mozilla receives video and image file links to process and display them in the Hubs Room. Mozilla stores this data as long as you remain in the Room. If you pin a video, image, or object in the Room, Mozilla will store that information until the object or room is deleted.
-- **Scenes and Avatars You Share**: Mozilla receives 3D Room model links, 3D Avatar information, and the name of the Room or Avatar in order to process and display the Room or Avatar. Mozilla stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
-- **Search**: You can search for images, GIFs, and 3D Models to share in Hubs. We use third-party search providers. When you search, we will send your searches to these third parties, which have their own privacy policies.
-  - Microsoft Bing Video & Image Search: <https://privacy.microsoft.com/en-us/privacystatement>
-  - Tenor: <https://tenor.com/legal-privacy>
-  - Sketchfab: <https://sketchfab.com/privacy>
-  - Google Poly & YouTube: <https://policies.google.com/privacy>
-  - Twitch: <https://www.twitch.tv/p/legal/privacy-policy/>
+**Avatar data**: Your selected avatar and name will be shared with other participants in your room. If you’re logged in to your account, we will store your avatar. If you’re not logged into your account, we will not store your avatar.
 
-### Mozilla receives data when you create and publish Scenes with Spoke or create a custom Avatar. {: #MozillaReceivesData2 }
+**Voice data**: If your microphone is on, Hubs sends the audio to other users in the room. Mozilla does not store the audio; we only receive it temporarily to transmit it to others in the room.
 
-- **Scenes and Avatars You Create**: When you create a scene with Spoke or a custom avatar, Mozilla receives a copy of that scene or avatar. Mozilla stores that data in order to be able to process and display the scene or avatar through Hubs.
-- **Publishing Your Scene or Avatar**: When you publish a scene or avatar to Hubs, Mozilla will ask for your email address to send you a link to verify your email. Mozilla will receive and store your email address to allow you to log in and view your 3D Room models and Avatars. Mozilla stores a hashed version of email addresses you use to publish a scene, so the stored versions are not available in readable form.
-- **Remixing, Promotion, and Favorites**: When you publish a scene or avatar to Hubs, you have the option to “Allow Remixing with Creative Commons [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/)” or allow Mozilla to promote your scene or avatar. If you choose one or both of these options, Mozilla will share your scene or avatar publicly and you will have the option of including attribution information, which will also be publicly available. If you mark a Room or Avatar as a Favorite, Mozilla will store that information associated with your account.
+**Chat**: If you send messages in Hubs, Hubs shares it with the other users in the room. Mozilla does not store chats; we only receive it temporarily to transmit it to others in the room.
 
-- You can learn more by looking at the [code itself](https://github.com/mozilla/spoke) for Spoke.
+**Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, Mozilla stores them so you can share them within the room. They are deleted within 72 hours unless you pin them. If you pin them they will be stored until you remove them from the room and they will be viewable by anyone who can access the room.
 
-### Mozilla receives technical and interaction data to improve performance and stability for Hubs.
+You can learn more by looking at the code itself: [Hubs](https://github.com/mozilla/hubs) (the front-end) [Dialog](https://github.com/mozilla/dialog/) (the webRTC server), [Reticulum](https://github.com/mozilla/reticulum) (the backend web server), [Hubs-Ops](https://github.com/mozilla/hubs-ops) (the infrastructure code), [Discord Bot](https://github.com/MozillaReality/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
 
-- **Account data**: You do not need to create an account to use Hubs. If you decide to create an account with your email address, we receive your email address to send you a login link, but stores only a hashed version of your email address. If you decide to use Discord to create your account, we receive the email address associated with your Discord account and your Discord avatar.
-- **Technical data**: We receive and store data about Room URLs and names; the type of device you use to interact with Hubs, as well as its operating system, language, the name and version of browser; and other data to load and operate the Room.
-- **Interaction data**: We receive data about your interactions with the Hubs service itself such as the number of Rooms created, messages sent through or to third-party services like Slack and Discord, the maximum number of users in a particular room at one same time, the start and end time of a user’s interaction with Hubs, the amount of time a user interacts with Hubs through Virtual Reality, the first time in a particular month or day that a user begins to use Hubs. Mozilla uses third party services to store and analyze these operational messages. We also also use Google Analytics, which places a cookie on your device, to obtain metrics on how users engage with our websites. This helps us to improve site content.
-- **Error Data**: In order to diagnose problems, Hubs sends Mozilla logs of error messages (which include the Room URL, response time for requests, the page you were on when you encountered the error, your operating system, browser information, and may include your IP address).
-- You can learn more by looking at the [code itself](https://github.com/mozilla/hubs) for Hubs.  [Janus SFU](https://github.com/mozilla/janus-plugin-sfu), [Reticulum](https://github.com/mozilla/reticulum), [Hubs](https://github.com/mozilla/hubs), [Hubs-Ops](https://github.com/mozilla/hubs-ops), [Discord Bot](https://github.com/MozillaReality/hubs-discord-bot)
+### Other Information We Receive
+
+We use technical, interaction, error, and website analytics data to help us improve the Hubs and Spoke experiences:
+
+**Technical data**: We receive data about the type of device you use to interact with Hubs, as well as its operating system, language, the name and version of browser, and other data needed to load and operate a room.
+
+**Interaction data**: We receive data about your interactions with Hubs, such as the number of rooms created, messages sent through or to third-party services like Discord (including aggregated counts such as the number of messages and users who have joined relevant channels), the number of users in a particular room, the start and end time of a your interaction with Hubs, the amount of time you interact with Hubs through virtual reality, the first time in a particular month or day that you begins to use Hubs.
+
+**Error Data**: When Hubs or Spoke crashes or fails, Mozilla receives error messages which may include the room URL, response time for requests, the page you were on when you encountered the error, your operating system, browser information, and your IP address.
+
+**Website Analytics Data**: We use Google Analytics (GA) to better understand how you interact with Hubs and Spoke For example, we collect de-identified information about the number of Hubs rooms you create or enter, your interactions with buttons and menus, your session length, your location (country, state/province, and city), language settings, your browser type and version, viewport size, and screen resolution. You can opt-out of GA data collection by installing the [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout).
+
+## Information We Collect When Your Create and Publish Scenes or Custom Avatars
+
+**Scenes and avatars you create**: You need an account to create scenes in Spoke and custom avatars in Hubs. When you create a scene or custom avatar, Mozilla stores that scene or avatar so we can display it.
+
+**Attribution information**: When you publish a scene or avatar to Hubs, you have the option to “Allow Remixing with Creative Commons [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/)” or allow Mozilla to promote your scene or avatar. If you choose one or both of these options, Mozilla will share your scene or avatar and your attribution information publicly.
+
+**Account information**: To publish a scene or avatar to Hubs, you need to have a Hubs account. Mozilla will receive and store a hashed version of your email address to allow you to log in and view your 3D Room models and Avatars.
+
+You can learn more by looking at the [code itself](https://github.com/mozilla/spoke) for Spoke.
+
+## Who Hubs May Disclose Information To
+
+**Amazon Web Services (AWS)**: Hubs and Spoke use Amazon’s cloud storage service to store the information collected through Hubs and Spoke. You can read [AWS’s Privacy Notice](https://aws.amazon.com/privacy/) for more information.
+
+**Search providers**: You can search for images, GIFs, and 3D Models to share in Hubs. When you search, we will send your searches to supported third parties to fulfill the search. Mozilla does not store your search queries or the search results. We support the following providers:
+
+- [Tenor](https://tenor.com/legal-privacy)
+
+- [Sketchfab](https://sketchfab.com/privacy)
+
+- [YouTube](https://policies.google.com/privacy)
+
+- [Twitch](https://www.twitch.tv/p/legal/privacy-policy/)
+
+**Twitter**: If you connect Twitter to Hubs, you can tweet and share 2D images from Hubs rooms. Any content you tweet will be shared with Twitter and published on the Twitter platform. You can see Twitter’s [Privacy Policy](https://twitter.com/en/privacy) for more information.
+
+**Discord**: If you connect Discord to Hubs, we store access tokens and the server and channel IDs that have been connected. We will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel. Hubs does not log any synchronized messages. You can see [Discord’s Privacy Policy](https://discordapp.com/privacy) for more information.

--- a/en/mozilla_hubs_tos.md
+++ b/en/mozilla_hubs_tos.md
@@ -34,15 +34,15 @@ You are solely responsible for the information you send, create, or edit using H
 
 ## 3. Conditions of Use
 
-By using Hubs or Spoke, you agree that your use will comply with Mozilla’s [Conditions of Use](https://www.mozilla.org/en-US/about/legal/acceptable-use/). Mozilla reserves the right to remove any content, suspend any users, and shut down any room it reasonably believes has violated these conditions.
+By using Hubs or Spoke, you agree that your use will comply with Mozilla’s [Conditions of Use](https://www.mozilla.org/about/legal/acceptable-use/). Mozilla reserves the right to remove any content, suspend any users, and shut down any room it reasonably believes has violated these conditions.
 
-Please also be aware of [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/), which address participation in Mozilla communities.
+Please also be aware of [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/), which address participation in Mozilla communities.
 
 ## 4. Mozilla's Rights
 
 Mozilla does not grant you any intellectual property rights in Hubs or Spoke unless these Terms specifically say otherwise. For example, these Terms do not provide the right to use any of Mozilla’s copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.
 
-Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozilla/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).
+Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozilla/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/MPL/2.0/FAQ/).
 
 ## 5. Services Interruption; Term; Termination
 
@@ -83,6 +83,6 @@ If any portion of these Terms is held to be invalid or unenforceable, the remain
 
 For support, to provide feedback, or to report abuse of Hubs or Spoke or violations of the Conditions of Use, you can email us at [hubs@mozilla.com](mailto:hubs@mozilla.com).
 
-To report a claim of copyright or trademark infringement, see [our policy](https://www.mozilla.org/en-US/about/legal/report-infringement/).
+To report a claim of copyright or trademark infringement, see [our policy](https://www.mozilla.org/about/legal/report-infringement/).
 
 For other notices, you may email us at [legal-notices@mozilla.com](mailto:legal-notices@mozilla.com) or write to us at Mozilla Corporation (Attn: Mozilla  Legal Notices, 2 Harrison Street, San Francisco CA 94105).

--- a/en/mozilla_hubs_tos.md
+++ b/en/mozilla_hubs_tos.md
@@ -1,47 +1,51 @@
 # Terms of Service for Hubs and Spoke
 
-Version 3.2, Effective March 12, 2019
-{: datetime="2019-03-12" }
+Version 3.4, Effective February 9, 2020
+{: datetime="2020-02-09" }
 
 [Hubs by Mozilla](https://hubs.mozilla.com) is a real-time communications platform for Virtual Reality, Augmented Reality, Desktop, Laptop, Mobile, or however else you browse the internet.
 
-Spoke is a tool to arrange 3D models into scenes for use in Hubs. 
+Spoke is a tool to arrange 3D models into scenes for use in Hubs.
 
 These Terms of Service explain your rights and responsibilities when you use Hubs and Spoke.
 
-### 1. Privacy Policy
+## 1. Privacy Policy
+
 The Hubs [Privacy Notice](https://github.com/mozilla/hubs/blob/master/PRIVACY.md) explains what information we collect when you use Hubs or Spoke and how that information is handled and shared.
 
-### 2. Communications and Content
+## 2. Communications and Content
 
-Hubs allows users to send information (such as audio, video, text, images, 3D models, and scenes) to other users. 
+Hubs allows users to send information (such as audio, video, text, images, 3D models, and scenes) to other users.
 
-Spoke allows users to arrange 3D Room models into scenes that can appear in Hubs. You can also use Hubs to customize your in-room Avatar. 
+Spoke allows users to arrange 3D Room models into scenes that can appear in Hubs. You can also use Hubs to customize your in-room Avatar.
 
-By using Hubs or Spoke, you agree to give Mozilla all rights necessary to operate Hubs and Spoke. This includes, but is not limited to, a license and permission to process, transmit, and display the information you send through Hubs or Spoke. It also includes permission to gather and share information as described in the [Privacy Notice](https://github.com/mozilla/hubs/blob/master/PRIVACY.md) for Hubs and Spoke. 
+By using Hubs or Spoke, you agree to give Mozilla all rights necessary to operate Hubs and Spoke. This includes, but is not limited to, a license and permission to process, transmit, and display the information you send through Hubs or Spoke. It also includes permission to gather and share information as described in the [Privacy Notice](https://github.com/mozilla/hubs/blob/master/PRIVACY.md) for Hubs and Spoke.
 
-When you submit information to Hubs or Spoke, you grant us a worldwide, royalty-free, perpetual, irrevocable, non-exclusive, transferable, and sublicensable license to use, copy, modify, adapt, prepare derivative works from, distribute, perform, and display that information, audio, video, images, or 3D models. You also agree that we may remove metadata associated with the information or data you submit, and you irrevocably waive any claims and assertions of moral rights or attribution with respect to the data you submit. If you allow allow remixing of a scene or avatar you create, you agree to license your scene under a [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/legalcode) license. 
+When you submit information to Hubs or Spoke, you continue to own the rights to your content. You grant us a worldwide, royalty-free, perpetual, irrevocable, non-exclusive, transferable, and sublicensable license to use, copy, modify, adapt, prepare derivative works from, distribute, perform, and display that information, audio, video, images, or 3D models for the purpose of operating Hubs and Spoke. You also agree that we may remove metadata associated with the information or data you submit. If you allow allow remixing of a scene or avatar you create, you agree to license your scene under a [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/legalcode) license.
 
-You also represent and warrant that you have the authority to grant Mozilla all rights and permissions necessary for the operation of Hubs and Spoke. 
+You also represent and warrant that you have the authority to grant Mozilla all rights and permissions necessary for the operation of Hubs and Spoke.
 
 To learn more about how Hubs operates, you can see the source code [here](https://github.com/mozilla/hubs).
 To learn more about how Spoke operates, you can see the source code [here](https://github.com/mozilla/spoke).
 
 Any ideas, suggestions, and feedback about Hubs or Spoke that you provide to us are entirely voluntary, and you agree that Mozilla may use such ideas, suggestions, and feedback without compensation or obligation to you.
 
-You are solely responsible for the information you send, create, or edit using Hubs or Spoke, and the consequences of sending, creating, or editing that information. 
+You are solely responsible for the information you send, create, or edit using Hubs or Spoke, and the consequences of sending, creating, or editing that information.
 
-### 3. Conditions of Use 
-By using Hubs or Spoke, you agree that your use will comply with Mozilla’s [Conditions of Use](https://www.mozilla.org/about/legal/acceptable-use/). Mozilla reserves the right to remove any content, suspend any users, and shut down any room it reasonably believes has violated these conditions.
+## 3. Conditions of Use
 
-Please also be aware of [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/), which address participation in Mozilla communities. 
+By using Hubs or Spoke, you agree that your use will comply with Mozilla’s [Conditions of Use](https://www.mozilla.org/en-US/about/legal/acceptable-use/). Mozilla reserves the right to remove any content, suspend any users, and shut down any room it reasonably believes has violated these conditions.
 
-### 4. Mozilla's Rights
+Please also be aware of [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/), which address participation in Mozilla communities.
+
+## 4. Mozilla's Rights
+
 Mozilla does not grant you any intellectual property rights in Hubs or Spoke unless these Terms specifically say otherwise. For example, these Terms do not provide the right to use any of Mozilla’s copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.
 
-Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozilla/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/MPL/2.0/FAQ/).
+Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozilla/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).
 
-### 5. Services Interruption; Term; Termination
+## 5. Services Interruption; Term; Termination
+
 We are continuing to develop Hubs and Spoke. As a result, we plan to upgrade and change them over time. To do this, we might have to temporarily suspend their service and it is not always possible for us to give notice. You will not be entitled to claim expenses or damages for such suspension or limitation of the use of Hubs or Spoke.
 
 These Terms apply to your use of Hubs and Spoke and will continue to apply until ended by either you or upon notice from Mozilla. You can choose to end them at any time for any reason by discontinuing your use of Hubs and Spoke.
@@ -50,10 +54,12 @@ We may cut off your access to Hubs or Spoke, either temporarily or permanently a
 
 In all such cases, these Terms shall terminate, including, without limitation, your license to use Hubs and Spoke, except that the sections with the following titles shall continue to apply: Indemnification, Disclaimer; Limitation of Liability and Miscellaneous.
 
-### 6. Indemnification
+## 6. Indemnification
+
 You agree to defend, indemnify and hold harmless Mozilla, and its respective parent and affiliate companies, contractors, contributors, licensors, partners, directors, officers, employees and agents ("Indemnified Parties") from and against any and all third party claims and expenses, including attorneys' fees, arising out of or related to your use of Hubs or Spoke. This includes, but is not limited to, claims and expenses from any content you transmit, edit, or create using Hubs or Spoke.
 
-### 7. Disclaimer; Limitation of Liability
+## 7. Disclaimer; Limitation of Liability
+
 THE SERVICES ARE PROVIDED "AS IS" WITH ALL FAULTS. TO THE EXTENT PERMITTED BY LAW, THE INDEMNIFIED PARTIES, HEREBY DISCLAIM ALL WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES THAT THE SERVICES ARE FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE, AND NON-INFRINGING.
 
 YOU BEAR THE ENTIRE RISK AS TO SELECTING THE SERVICES FOR YOUR PURPOSES AND AS TO THE QUALITY AND PERFORMANCE OF THE SERVICES, INCLUDING WITHOUT LIMITATION THE RISK THAT YOUR CONTENT IS DELETED OR CORRUPTED.
@@ -61,19 +67,22 @@ THIS LIMITATION WILL APPLY NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF A
 
 EXCEPT AS REQUIRED BY LAW, THE INDEMNIFIED PARTIES, WILL NOT BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING OUT OF OR IN ANY WAY RELATING TO THESE TERMS OR THE USE OF OR INABILITY TO USE THE SERVICES, INCLUDING WITHOUT LIMITATION DIRECT AND INDIRECT DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, LOST PROFITS, LOSS OF DATA, AND COMPUTER FAILURE OR MALFUNCTION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF THE THEORY (CONTRACT, TORT, OR OTHERWISE) UPON WHICH SUCH CLAIM IS BASED. THE COLLECTIVE LIABILITY OF THE INDEMNIFIED PARTIES, UNDER THIS AGREEMENT WILL NOT EXCEED $500 (FIVE HUNDRED DOLLARS). SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
 
-### 8. Modifications to These Terms
+## 8. Modifications to These Terms
+
 Mozilla may update these Terms from time to time. We will post the updated Terms online. If the changes are substantive, we may announce the update through Mozilla's usual channels for such announcements such as blog posts, forums, or in the particular service itself, in this case: Hubs and Spoke.
 
 Your continued use of Hubs or Spoke after we post the new Terms constitutes your acceptance of the new Terms. To make your review more convenient, we will post an effective date at the top of this page.
 
-### 9. Miscellaneous
+## 9. Miscellaneous
+
 These Terms make up the entire agreement between you and Mozilla concerning Hubs and Spoke. The laws of the state of California, U.S.A (excluding its conflict of law provisions) govern this agreement.
 
 If any portion of these Terms is held to be invalid or unenforceable, the remaining portions remain in full force and effect. If there is a conflict or ambiguity between a translated version of these terms and the English language version, the English language version applies.
 
-### 10. Contact Us
-For support, to provide feedback, or to report abuse of Hubs or Spoke or violations of the Conditions of Use, you can email us at [hubs@mozilla.com](mailto:hubs@mozilla.com). 
+## 10. Contact Us
 
-To report a claim of copyright or trademark infringement, see [our policy](https://www.mozilla.org/about/legal/report-infringement/). 
+For support, to provide feedback, or to report abuse of Hubs or Spoke or violations of the Conditions of Use, you can email us at [hubs@mozilla.com](mailto:hubs@mozilla.com).
+
+To report a claim of copyright or trademark infringement, see [our policy](https://www.mozilla.org/en-US/about/legal/report-infringement/).
 
 For other notices, you may email us at [legal-notices@mozilla.com](mailto:legal-notices@mozilla.com) or write to us at Mozilla Corporation (Attn: Mozilla  Legal Notices, 2 Harrison Street, San Francisco CA 94105).


### PR DESCRIPTION
The current formatting of the Hubs Privacy document uses `<details>` tags, which are not parsed correctly by the Bedrock legal-docs importer and also differs from how sibling documents (eg MDN Plus privacy notice) are formatted.

This changeset simplifies the markdown so that the import and rendering works. Below are two screenshots from the Bedrock branch that will support using the updated file once it reaches `main` and `prod`

NB: While the changes are unlikely break any other existing use of the document, it will change the formatting, because it removes the `<details>` markup, which automatically creates expandable sections in some contexts. Eg there were nested `<details>` but I couldn't represent them with a parent `h3` and then child `h4`s, because the CSS for legal docs in bedrock shows `h4`s as very small.

![Screenshot 2022-06-12 at 11-06-32 Privacy Notice for Hubs and Spoke](https://user-images.githubusercontent.com/101457/173228345-debebfed-9dd3-4598-be10-279ca4316b9c.png)

![Screenshot 2022-06-12 at 11-06-47 Privacy Notice for Hubs and Spoke](https://user-images.githubusercontent.com/101457/173228377-c56c7c87-f832-4e71-a06e-3ecb8ffb4d67.png)


