### PR TITLE
Fix subscription services markdown formatting

### DIFF
--- a/en/subscription_services_privacy_notice.md
+++ b/en/subscription_services_privacy_notice.md
@@ -1,13 +1,13 @@
 # Mozilla Subscription Services | Privacy Notice
 
-Version 1.0, Effective October 11, 2022 
+Version 1.0, Effective October 11, 2022
 {: datetime="2022-10-11" }
 
-__At Mozilla, we design products with your privacy in mind.__
+## At Mozilla, we design products with your privacy in mind.
 
 __Mozilla VPN__ protects your device’s internet connections. Mozilla partners with Mullvad to privately and securely encrypt your internet traffic.
 
-__Firefox Relay__ allows you to keep your primary email address and phone number safe and private from online services by making a unique, random (mask) phone number and email address(es). 
+__Firefox Relay__ allows you to keep your primary email address and phone number safe and private from online services by making a unique, random (mask) phone number and email address(es).
 
 This privacy notice explains what data Firefox Relay and Mozilla VPN collect, share, and why. We also adhere to the [Mozilla Privacy Policy](https://www.mozilla.org/privacy/) for how we receive, handle, and share information.
 
@@ -22,14 +22,15 @@ __Interaction data.__ Mozilla receives data about your interactions with the Ser
 __Technical data.__ Mozilla receives basic information about the installed version of your VPN or Relay Add-on software, and the device they are installed on, including the operating system and hardware configuration. Your IP address is temporarily collected as part of our server logs for 90 days. No server logs of your network activity are maintained by neither Mozilla nor our partner Mullvad when you're using the Mozilla VPN service.
 We use the data to improve performance and stability for our users, and to measure the Services’ performance.
 
-## Mozilla VPN {: #markup }
+### Mozilla VPN {: #vpn }
+
 __Location data.__ Mozilla VPN receives your IP address when you sign up for and use the service. We use the IP address in order to approximate your location to set which VPN server you connect to and because Mozilla VPN availability, pricing and offers may depend on your country.
 
 __Campaign and referral data.__ This helps Mozilla VPN understand the effectiveness of our marketing campaigns. Upon installation of the app, Mozilla may receive your IP address in addition to campaign data and referral data like what ad campaigns you engaged with and your operating system, device type, device identifiers, and operating system version. Mozilla shares this with Adjust, but we do not share or store your IP address. Read the [Adjust documentation](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/src/adjust/adjust.md).
 
 __Network data.__ Mullvad receives your internet traffic to provide the service. When you activate Mozilla VPN, it will encrypt your internet traffic and send it to Mullvad. Mullvad has committed not to log any of the data it receives. Learn more at [Mullvad’s Privacy Policy](https://mullvad.net/help/no-logging-data-policy/).
 
-## Firefox Relay {: #markup }
+### Firefox Relay {: #relay }
 
 __Email messages.__ To send and forward your email messages from your masked email address(es) to your primary email address, Firefox Relay processes your email messages. We do not read or store the content of any of your messages. In the event that an email cannot be delivered to you, we will keep it on our servers and delete it after it has been delivered (in no event will we hold onto it for more than three days). If you use the feature to block promotional emails, the Service will check email headers to determine whether the email should be blocked.
 
@@ -43,7 +44,7 @@ __Information We Share.__ Firefox Relay shares information with third parties to
 
 * __[Amazon Web Services.](https://aws.amazon.com/privacy/)__ Amazon Web Services (AWS) is a cloud-computing platform. Firefox Relay uses AWS to receive emails sent to your masked email address(es) and to forward them to the primary email address associated with your Firefox account. Only Mozilla knows the association between your primary email address and your masked email address(es).
 
-* __[Twilio.](https://www.twilio.com)__ Twilio receives your phone number, your phone mask, and the phone numbers that you exchange phone calls and text messages with. Twilio also receives the content of text messages you send and receive through Firefox Relay and Mozilla has set the Twilio service to delete its records of the text messages you send and receive through Firefox Relay after 7 days. 
+* __[Twilio.](https://www.twilio.com)__ Twilio receives your phone number, your phone mask, and the phone numbers that you exchange phone calls and text messages with. Twilio also receives the content of text messages you send and receive through Firefox Relay and Mozilla has set the Twilio service to delete its records of the text messages you send and receive through Firefox Relay after 7 days.
 
 ## Other Information You Should Know
 


### PR DESCRIPTION
@mafeld these changes should make it so only "Mozilla VPN" and "Firefox Relay" sections are expandable