### PR TITLE
Add PDF sources for Hubs and Subscription Services

### DIFF
--- a/.github/scripts/pdf_sources.json
+++ b/.github/scripts/pdf_sources.json
@@ -4,10 +4,10 @@
         "firefox_relay_tos.md",
         "mdn_plus_privacy.md",
         "mdn_plus_terms.md",
-        "mozilla_vpn_privacy_notice.md",
-        "mozilla_vpn_tos.md",
         "mozilla_hubs_privacy_notice.md",
         "mozilla_hubs_tos.md",
+        "mozilla_vpn_privacy_notice.md",
+        "mozilla_vpn_tos.md",
         "subscription_services_privacy_notice.md",
         "subscription_services_tos.md"
     ]

--- a/.github/scripts/pdf_sources.json
+++ b/.github/scripts/pdf_sources.json
@@ -5,6 +5,10 @@
         "mdn_plus_privacy.md",
         "mdn_plus_terms.md",
         "mozilla_vpn_privacy_notice.md",
-        "mozilla_vpn_tos.md"
+        "mozilla_vpn_tos.md",
+        "mozilla_hubs_privacy_notice.md",
+        "mozilla_hubs_tos.md",
+        "subscription_services_privacy_notice.md",
+        "subscription_services_tos.md"
     ]
 }


### PR DESCRIPTION
Add PDF sources for Hubs and Subscription Services, so that the necessary PDFs are generated by the `convert_to_pdf.py` script called by Github Action `PDF generation`.

This will allow the FxA team to copy the latest generated PDFs to the Mozilla FXA repo.