### PR TITLE
Updates Attribute Lists extension link in README Markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you've submitted a pull request, your colleagues can review the work under 
 
 These files are written in the [Markdown syntax](https://daringfireball.net/projects/markdown/syntax). In some languages, the date format contains dots like `15. travnja 2014.` but this may end up as an ordered list according to the syntax. The workaround is using a backslash to escape a dot after the leading digit(s) like `15\. travnja 2014.`
 
-Some Markdown files use the [Attribute Lists extension](https://pythonhosted.org/Markdown/extensions/attr_list.html) of the [Python Markdown library](https://pypi.python.org/pypi/Markdown). This is useful when you'd like to set the ID or class of an element, but the extended syntax may cause an error if your parser doesn't support this extension.
+Some Markdown files use the [Attribute Lists extension](https://python-markdown.github.io/extensions/attr_list/) of the [Python Markdown library](https://pypi.python.org/pypi/Markdown). This is useful when you'd like to set the ID or class of an element, but the extended syntax may cause an error if your parser doesn't support this extension.
 
 ### PDF
 


### PR DESCRIPTION
The original link 404s, but maybe hopefully this is the correct replacement URL.

Fixes #1873