### PR TITLE
Add Pocket iOS license (new document)

### DIFF
--- a/en/pocket_license_ios.md
+++ b/en/pocket_license_ios.md
@@ -1,0 +1,2091 @@
+Pocket iOS Third-Party Software Notices
+This document contains licensing information relating to the use of free and open-source software (FOSS) with or within the Pocket for IOS software.  Any terms, conditions, or restrictions on FOSS included within the Pocket for IOS software that are not included within the original FOSS licenses are offered and imposed by Pocket alone.  The authors, licensors, and distributors of the FOSS disclaim all express or implied conditions, representations, and warranties relating to the FOSS and any liability arising from use and distribution of the FOSS.
+This document identifies the FOSS packages used in the Pocket for IOS software, the FOSS licenses that Pocket believes govern those FOSS packages, and copyright and license notices associated with Pocket’s use of the FOSS.  While Pocket has sought to provide complete and accurate licensing information for each FOSS package, Pocket does not represent or warrant that the licensing information provided herein is correct or error-free.  Recipients of the product should investigate the identified FOSS packages to confirm the accuracy of the licensing information provided herein.  Recipients are also encouraged to notify Pocket of any inaccurate information or errors found in these notices.
+The FOSS packages identified below are arranged by the applicable license(s).
+
+## Apollo
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Apollo Graph, Inc. (Formerly Meteor Development Group, Inc.)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## braze-swift-sdk
+
+Copyright (c) 2022 Braze, Inc.
+All rights reserved.
+
+* Use of source code or binaries contained within Braze’s SDKs is permitted only to enable use of the Braze platform by customers of Braze.
+* Modification of source code and inclusion in mobile apps is explicitly allowed provided that all other conditions are met.
+* Neither the name of Braze nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+* Redistribution of source code or binaries is disallowed except with specific prior written permission. Any such redistribution must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+## DangerSwiftCoverage
+
+MIT License
+
+Copyright (c) 2019 Franco Meloni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## Down
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Rob Phillips.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
+cmark
+
+Copyright (c) 2014, John MacFarlane
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright
+  	notice, this list of conditions and the following disclaimer.
+
+	* Redistributions in binary form must reproduce the above
+  	copyright notice, this list of conditions and the following
+  	disclaimer in the documentation and/or other materials provided
+  	with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+houdini.h, houdini_href_e.c, houdini_html_e.c, houdini_html_u.c,
+html_unescape.gperf, html_unescape.h
+
+derive from https://github.com/vmg/houdini (with some modifications)
+
+Copyright (C) 2012 Vicent Martí
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+buffer.h, buffer.c, chunk.h
+
+are derived from code (C) 2012 Github, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+utf8.c and utf8.c
+
+are derived from utf8proc
+(<https://www.public-software-group.org/utf8proc>),
+(C) 2009 Public Software Group e. V., Berlin, Germany.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+-----
+
+The normalization code in runtests.py was derived from the
+markdowntest project, Copyright 2013 Karl Dubost:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Karl Dubost
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The CommonMark spec (test/spec.txt) is
+
+Copyright (C) 2014-15 John MacFarlane
+
+Released under the Creative Commons CC-BY-SA 4.0 license:
+<https://creativecommons.org/licenses/by-sa/4.0/>.
+
+-----
+
+The test software in test/ is
+
+Copyright (c) 2014, John MacFarlane
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright
+  	notice, this list of conditions and the following disclaimer.
+
+	* Redistributions in binary form must reproduce the above
+  	copyright notice, this list of conditions and the following
+  	disclaimer in the documentation and/or other materials provided
+  	with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+The normalization code in runtests.py was derived from the
+markdowntest project, Copyright 2013 Karl Dubost:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Karl Dubost
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## FMDB
+
+If you are using FMDB in your project, I'd love to hear about it.  Let Gus know
+by sending an email to gus@flyingmeat.com.
+
+And if you happen to come across either Gus Mueller or Rob Ryan in a bar, you
+might consider purchasing a drink of their choosing if FMDB has been useful to
+you.
+
+Finally, and shortly, this is the MIT License.
+
+Copyright (c) 2008-2014 Flying Meat Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+## InflectorKit
+
+Copyright (c) 2013 - 2020 Mattt (https://mat.tt)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+## Kingfisher
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Wei Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+## Logger
+
+MIT License
+
+Copyright (c) 2022 Shiba Package Manager
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## Lottie
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "{}"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+   Copyright 2018 Airbnb, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   	https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+## OctoKit
+
+Copyright (c) 2015 Piet Brauer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+## RequestKit
+
+Copyright (c) 2015 Piet Brauer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+## Sails
+
+The MIT License (MIT)
+
+Copyright (c) 2022 Sails contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## SDWebImage
+
+Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+## Sentry
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+## SnowplowTracker
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "{}"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+   Copyright 2022 Snowplow Analytics Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+## SQLite.swift
+
+(The MIT License)
+
+Copyright (c) 2014-2015 Stephen Celis (<stephen@stephencelis.com>)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## danger-swift
+
+MIT License
+
+Copyright (c) 2017-2022 Danger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## swift-argument-parser
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+	TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+	1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+	2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+	3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+	4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+	5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+	6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+	7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+	8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+	9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+	END OF TERMS AND CONDITIONS
+
+	APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "[]"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+	Copyright [yyyy] [name of copyright owner]
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+	As an exception, if you use this Software to compile your source code and
+	portions of this Software are embedded into the binary product as a result,
+	you may redistribute such product without providing attribution as would
+	otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+## swift-atomics
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+	TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+	1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+	2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+	3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+	4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+	5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+	6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+	7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+	8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+	9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+	END OF TERMS AND CONDITIONS
+
+	APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "[]"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+	Copyright [yyyy] [name of copyright owner]
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+	As an exception, if you use this Software to compile your source code and
+	portions of this Software are embedded into the binary product as a result,
+	you may redistribute such product without providing attribution as would
+	otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+## swift-collections
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+	TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+	1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+	2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+	3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+	4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+	5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+	6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+	7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+	8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+	9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+	END OF TERMS AND CONDITIONS
+
+	APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "[]"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+	Copyright [yyyy] [name of copyright owner]
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+	As an exception, if you use this Software to compile your source code and
+	portions of this Software are embedded into the binary product as a result,
+	you may redistribute such product without providing attribution as would
+	otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+## swift-nio
+
+
+                             	Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "[]"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+## SwiftyBeaver
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Sebastian Kreutzberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## Version
+
+  Apache License
+                       	Version 2.0, January 2004
+                    	http://www.apache.org/licenses/
+
+	TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+	1. Definitions.
+
+  	"License" shall mean the terms and conditions for use, reproduction,
+  	and distribution as defined by Sections 1 through 9 of this document.
+
+  	"Licensor" shall mean the copyright owner or entity authorized by
+  	the copyright owner that is granting the License.
+
+  	"Legal Entity" shall mean the union of the acting entity and all
+  	other entities that control, are controlled by, or are under common
+  	control with that entity. For the purposes of this definition,
+  	"control" means (i) the power, direct or indirect, to cause the
+  	direction or management of such entity, whether by contract or
+  	otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  	outstanding shares, or (iii) beneficial ownership of such entity.
+
+  	"You" (or "Your") shall mean an individual or Legal Entity
+  	exercising permissions granted by this License.
+
+  	"Source" form shall mean the preferred form for making modifications,
+  	including but not limited to software source code, documentation
+  	source, and configuration files.
+
+  	"Object" form shall mean any form resulting from mechanical
+  	transformation or translation of a Source form, including but
+  	not limited to compiled object code, generated documentation,
+  	and conversions to other media types.
+
+  	"Work" shall mean the work of authorship, whether in Source or
+  	Object form, made available under the License, as indicated by a
+  	copyright notice that is included in or attached to the work
+  	(an example is provided in the Appendix below).
+
+  	"Derivative Works" shall mean any work, whether in Source or Object
+  	form, that is based on (or derived from) the Work and for which the
+  	editorial revisions, annotations, elaborations, or other modifications
+  	represent, as a whole, an original work of authorship. For the purposes
+  	of this License, Derivative Works shall not include works that remain
+  	separable from, or merely link (or bind by name) to the interfaces of,
+  	the Work and Derivative Works thereof.
+
+  	"Contribution" shall mean any work of authorship, including
+  	the original version of the Work and any modifications or additions
+  	to that Work or Derivative Works thereof, that is intentionally
+  	submitted to Licensor for inclusion in the Work by the copyright owner
+  	or by an individual or Legal Entity authorized to submit on behalf of
+  	the copyright owner. For the purposes of this definition, "submitted"
+  	means any form of electronic, verbal, or written communication sent
+  	to the Licensor or its representatives, including but not limited to
+  	communication on electronic mailing lists, source code control systems,
+  	and issue tracking systems that are managed by, or on behalf of, the
+  	Licensor for the purpose of discussing and improving the Work, but
+  	excluding communication that is conspicuously marked or otherwise
+  	designated in writing by the copyright owner as "Not a Contribution."
+
+  	"Contributor" shall mean Licensor and any individual or Legal Entity
+  	on behalf of whom a Contribution has been received by Licensor and
+  	subsequently incorporated within the Work.
+
+	2. Grant of Copyright License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	copyright license to reproduce, prepare Derivative Works of,
+  	publicly display, publicly perform, sublicense, and distribute the
+  	Work and such Derivative Works in Source or Object form.
+
+	3. Grant of Patent License. Subject to the terms and conditions of
+  	this License, each Contributor hereby grants to You a perpetual,
+  	worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  	(except as stated in this section) patent license to make, have made,
+  	use, offer to sell, sell, import, and otherwise transfer the Work,
+  	where such license applies only to those patent claims licensable
+  	by such Contributor that are necessarily infringed by their
+  	Contribution(s) alone or by combination of their Contribution(s)
+  	with the Work to which such Contribution(s) was submitted. If You
+  	institute patent litigation against any entity (including a
+  	cross-claim or counterclaim in a lawsuit) alleging that the Work
+  	or a Contribution incorporated within the Work constitutes direct
+  	or contributory patent infringement, then any patent licenses
+  	granted to You under this License for that Work shall terminate
+  	as of the date such litigation is filed.
+
+	4. Redistribution. You may reproduce and distribute copies of the
+  	Work or Derivative Works thereof in any medium, with or without
+  	modifications, and in Source or Object form, provided that You
+  	meet the following conditions:
+
+  	(a) You must give any other recipients of the Work or
+      	Derivative Works a copy of this License; and
+
+  	(b) You must cause any modified files to carry prominent notices
+      	stating that You changed the files; and
+
+  	(c) You must retain, in the Source form of any Derivative Works
+      	that You distribute, all copyright, patent, trademark, and
+      	attribution notices from the Source form of the Work,
+      	excluding those notices that do not pertain to any part of
+      	the Derivative Works; and
+
+  	(d) If the Work includes a "NOTICE" text file as part of its
+      	distribution, then any Derivative Works that You distribute must
+      	include a readable copy of the attribution notices contained
+      	within such NOTICE file, excluding those notices that do not
+      	pertain to any part of the Derivative Works, in at least one
+      	of the following places: within a NOTICE text file distributed
+      	as part of the Derivative Works; within the Source form or
+      	documentation, if provided along with the Derivative Works; or,
+      	within a display generated by the Derivative Works, if and
+      	wherever such third-party notices normally appear. The contents
+      	of the NOTICE file are for informational purposes only and
+      	do not modify the License. You may add Your own attribution
+      	notices within Derivative Works that You distribute, alongside
+      	or as an addendum to the NOTICE text from the Work, provided
+      	that such additional attribution notices cannot be construed
+      	as modifying the License.
+
+  	You may add Your own copyright statement to Your modifications and
+  	may provide additional or different license terms and conditions
+  	for use, reproduction, or distribution of Your modifications, or
+  	for any such Derivative Works as a whole, provided Your use,
+  	reproduction, and distribution of the Work otherwise complies with
+  	the conditions stated in this License.
+
+	5. Submission of Contributions. Unless You explicitly state otherwise,
+  	any Contribution intentionally submitted for inclusion in the Work
+  	by You to the Licensor shall be under the terms and conditions of
+  	this License, without any additional terms or conditions.
+  	Notwithstanding the above, nothing herein shall supersede or modify
+  	the terms of any separate license agreement you may have executed
+  	with Licensor regarding such Contributions.
+
+	6. Trademarks. This License does not grant permission to use the trade
+  	names, trademarks, service marks, or product names of the Licensor,
+  	except as required for reasonable and customary use in describing the
+  	origin of the Work and reproducing the content of the NOTICE file.
+
+	7. Disclaimer of Warranty. Unless required by applicable law or
+  	agreed to in writing, Licensor provides the Work (and each
+  	Contributor provides its Contributions) on an "AS IS" BASIS,
+  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  	implied, including, without limitation, any warranties or conditions
+  	of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  	PARTICULAR PURPOSE. You are solely responsible for determining the
+  	appropriateness of using or redistributing the Work and assume any
+  	risks associated with Your exercise of permissions under this License.
+
+	8. Limitation of Liability. In no event and under no legal theory,
+  	whether in tort (including negligence), contract, or otherwise,
+  	unless required by applicable law (such as deliberate and grossly
+  	negligent acts) or agreed to in writing, shall any Contributor be
+  	liable to You for damages, including any direct, indirect, special,
+  	incidental, or consequential damages of any character arising as a
+  	result of this License or out of the use or inability to use the
+  	Work (including but not limited to damages for loss of goodwill,
+  	work stoppage, computer failure or malfunction, or any and all
+  	other commercial damages or losses), even if such Contributor
+  	has been advised of the possibility of such damages.
+
+	9. Accepting Warranty or Additional Liability. While redistributing
+  	the Work or Derivative Works thereof, You may choose to offer,
+  	and charge a fee for, acceptance of support, warranty, indemnity,
+  	or other liability obligations and/or rights consistent with this
+  	License. However, in accepting such obligations, You may act only
+  	on Your own behalf and on Your sole responsibility, not on behalf
+  	of any other Contributor, and only if You agree to indemnify,
+  	defend, and hold each Contributor harmless for any liability
+  	incurred by, or claims asserted against, such Contributor by reason
+  	of your accepting any such warranty or additional liability.
+
+	END OF TERMS AND CONDITIONS
+
+	APPENDIX: How to apply the Apache License to your work.
+
+  	To apply the Apache License to your work, attach the following
+  	boilerplate notice, with the fields enclosed by brackets "[]"
+  	replaced with your own identifying information. (Don't include
+  	the brackets!)  The text should be enclosed in the appropriate
+  	comment syntax for the file format. We also recommend that a
+  	file or class name and description of purpose be included on the
+  	same "printed page" as the copyright notice for easier
+  	identification within third-party archives.
+
+	Copyright [yyyy] [name of copyright owner]
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+   	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+	As an exception, if you use this Software to compile your source code and
+	portions of this Software are embedded into the binary product as a result,
+	you may redistribute such product without providing attribution as would
+	otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+## YouTubePlayerKit
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Sven Tiigi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+


### PR DESCRIPTION
Adding Pocket's new iOS open source license legal doc.

Note that this page does not need to be localized.

More information here: https://github.com/mozilla/bedrock/issues/12910