### PR TITLE
Update firefox_privacy_notice.md

### DIFF
--- a/en/firefox_privacy_notice.md
+++ b/en/firefox_privacy_notice.md
@@ -1,59 +1,65 @@
 ## <span class="privacy-header-firefox">Firefox</span> <span class="privacy-header-policy">Privacy Notice</span>
 
-*Effective July 27, 2023*
-{: datetime="2023-07-27" }
+*Effective November 1, 2023*
+{: datetime="2023-11-01" }
 
 ## At Mozilla, we believe that privacy is fundamental to a healthy internet.
 
 That’s why we build Firefox, and all our products, to give you greater control over the information you share online and the information you share with us. We strive to collect only what we need to improve Firefox for everyone.
 
-In this Privacy Notice, we explain what data Firefox shares and point you to settings to share even less. We also adhere to the practices outlined in the Mozilla [privacy policy](https://www.mozilla.org/privacy/) for how we receive, handle and share information we collect from Firefox.
+In this Privacy Notice, we explain what data Firefox shares and point you to settings to share even less. We also adhere to the practices outlined in the Mozilla [Privacy Policy](https://www.mozilla.org/privacy/) for how we receive, handle and share information we collect from Firefox.
 
-## Firefox by default shares data to:
+## By default, Mozilla processes your Firefox personal data to:
 
-### Improve performance and stability for users everywhere {: #health-report }
+### Improve features, performance and stability for users everywhere 
 
 * __Interaction data__: Firefox sends data about your interactions with Firefox to us (such as number of open tabs and windows; number of webpages visited; number and type of installed Firefox Add-ons; and session length) and Firefox features offered by Mozilla or our partners (such as interaction with Firefox search features and search partner referrals).
 
-* __Technical data__: Firefox sends data about your Firefox version and language; device operating system and hardware configuration; memory, basic information about crashes and errors; outcome of automated processes like updates, safebrowsing, and activation to us.  When Firefox sends data to us, your IP address is temporarily collected as part of our server logs.
+* __Technical data__: Firefox sends data about your Firefox version and language; device operating system and hardware configuration; memory, basic information about crashes and errors; outcome of automated processes like updates, safebrowsing, and activation to us. When Firefox sends data to us, your IP address is temporarily collected as part of our server logs.
 
-Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://dictionary.telemetry.mozilla.org/apps/fenix), or [iOS](https://dictionary.telemetry.mozilla.org/apps/firefox_ios) or learn how to opt-out of this data collection on [Desktop](https://support.mozilla.org/kb/share-data-mozilla-help-improve-firefox) and [Mobile](https://support.mozilla.org/kb/send-usage-data-firefox-mobile-browsers).
+Read the telemetry documentation for [Desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html), [Android](https://dictionary.telemetry.mozilla.org/apps/fenix), or [iOS](https://dictionary.telemetry.mozilla.org/apps/firefox_ios). Learn how to opt-out of this data collection on [Desktop](https://support.mozilla.org/kb/share-data-mozilla-help-improve-firefox) and [Mobile](https://support.mozilla.org/kb/send-usage-data-firefox-mobile-browsers), or opt out of [studies](https://support.mozilla.org/kb/shield).
 {: #telemetry }
 
-### Search {: #defaultsearch }
+### Provide search functionality {: #defaultsearch }
 
 You can perform searches directly from several places in Firefox, including the Awesome Bar, Search Bar, or on a New Tab. We receive data about how you engage with search in Firefox and the number of searches you request from our search partners. 
 
 * __Location data__: When you first use Firefox, it uses your IP address to set your default search provider based on your country. [Learn more](https://support.mozilla.org/kb/change-your-default-search-settings-firefox).
 
-* __Search queries__: Firefox by default sends search queries to your search provider to help you discover common phrases other people have searched for and improve your search experience if your selected search provider supports search suggestions. Your selected search provider’s privacy policy governs the search provider’s collection and use of your data as you use the search provider’s services. [Learn more](https://support.mozilla.org/kb/search-suggestions-firefox), including how to disable this feature. Links to our default search providers' privacy policies include:
+* __Search queries__: Firefox sends search queries to your search provider to enable your search and to help you discover common phrases other people have searched for and improve your search experience (if your selected search provider supports search suggestions). Your selected search provider’s privacy notice governs the search provider’s collection and use of your data as you use the search provider’s services. [Learn more](https://support.mozilla.org/kb/search-suggestions-firefox), including how to disable this feature. Links to our default search providers' privacy policies include:
 
   * [Google](https://policies.google.com/privacy)
   * [Microsoft (Bing)](https://privacy.microsoft.com/privacystatement)
 
 Mozilla generally receives royalties when you use one of the default or optional search options in the Firefox web browser, including but not limited to Google, Bing, DuckDuckGo, and eBay. 
 
-* If you enable "Improve the Firefox Suggest Experience," we and our partners may also receive your search queries. [Learn more below](#searches). 
+__Firefox Suggest__ uses data to help deliver better information with less effort. By default, Firefox Suggest shows you recommended and sponsored content based on local data stored on your own computer, such as websites from your browsing history, bookmarks and open tabs (which is not sent to Mozilla). Firefox Suggest does send to Mozilla:
 
+* __Location data__: Firefox temporarily sends Mozilla your IP address, which we use to suggest content based on your country, state, and city. Mozilla may share location information with our [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners), but partners will not receive your IP address. In the US, Mozilla may also receive keyword location search data (such as when you search for “Boston”) and share this with our partners to provide recommended and sponsored content. Where this occurs, neither Mozilla nor our partners are able to associate the keyword search with an individual user once the search suggestion has been served.
+
+* __Technical & interaction data__: Firefox sends Mozilla data such as the number of times Firefox suggests or displays specific content and your clicks on that content, as well as basic data about your interactions with Firefox Suggest. Mozilla shares information about how many times suggestions are shown, the position of the suggestion, and suggestions clicked on with our [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners) for verification and feature improvement.
+
+If you choose to opt-in to "Improve the Firefox Suggest Experience" on your settings page, Mozilla receives and processes the following information to improve your browsing experience and to improve the service:
+
+* __Search queries__: Firefox sends Mozilla what you type into the search bar and Mozilla may share that data with its [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners). We take measures to limit our and our partners’ ability to identify you. [Learn more](https://support.mozilla.org/kb/firefox-suggest).
+  
 ### Recommend relevant content
 
 Firefox displays content, such as Add-on Recommendations, Top Sites (websites suggested by Mozilla for first-time Firefox users), and Pocket Recommendations (which is part of the Mozilla family).
 
 * __Location data__: Firefox uses your IP address to suggest relevant content based on your country and state.
 
-* __Technical & Interaction data__: Firefox sends us data such as the position, size and placement of content we suggest, as well as basic data about your interactions with content. This includes the number of times content is displayed or clicked.
+* __Technical & Interaction data__: Firefox sends us data such as the position, size and placement of content we suggest, as well as basic data about your interactions with content. This includes the number of times content is displayed or clicked. We use Technical and Interaction data in order to better understand our users and improve our product. 
 
-* __Pocket Recommendations__: We recommend content to you based on your browsing history, language, and country location. The process of deciding which stories you should see based on your browsing history happens locally in your copy of Firefox, and neither Mozilla nor Pocket receives a copy of your browsing history. To help you see relevant Pocket Recommendations based on your location, Firefox shares your language and country location with Pocket.
-
-    Mozilla and Pocket receive aggregated data about the recommendations you see and click. We also share aggregated data about the sponsored content you see and click with our third-party ad platform Kevel so advertisers can see how many people click on their articles. This aggregated data does not identify you personally.
+* __Pocket Recommendations__: We recommend content to you based on your browsing history, language, and country location. The process of deciding which stories you should see based on your browsing history happens locally in your copy of Firefox, and Mozilla does not receive a copy of your browsing history. Mozilla does receive aggregated data about the recommendations you see and click. We also share aggregated data about the sponsored content you see and click with our third-party ad platform [Kevel](https://dev.kevel.com/docs/privacy-policy-customers) so advertisers can see how many people click on their articles. This aggregated data does not identify you personally.
 
 * __Top Sites__: When you click on a Sponsored Top Sites tile on New Tab, we share your country, region, county (if you're in the US), the tile you clicked, and the time you clicked with AdMarketplace (a third-party referral platform) to verify you navigated to the website. Firefox does not share your IP address or any other information that could be used to identify you.
 
-* __Add-on and Feature Recommendations__: We recommend Add-ons in two places: the Manage Your Extensions Page (about:addons) and the Awesome Bar, where you search or type in URLs. We may also recommend Firefox Features in the Awesome Bar. We base the recommendations in about:addons on a cookie. We base the recommendations in the Awesome Bar on your interaction with Firefox. Mozilla does not receive your browser history. The process happens locally in your own computer’s copy of Firefox. Learn More about [Awesome Bar recommendations](https://support.mozilla.org/kb/extension-recommendations) or [Extensions Page recommendations](https://support.mozilla.org/kb/personalized-extension-recommendations).
+* __Add-on and Feature Recommendations__: We recommend Add-ons in two places: the Manage Your Extensions Page (about:addons) and the Awesome Bar, where you search or type in URLs. We may also recommend Firefox Features in the Awesome Bar. We base the recommendations in about:addons on a cookie. We base the recommendations in the Awesome Bar on your interaction with Firefox. Mozilla does not receive your browser history. The process happens locally in your own computer’s copy of Firefox.  Learn More about [Awesome Bar recommendations](https://support.mozilla.org/kb/extension-recommendations) or [Extensions Page recommendations](https://support.mozilla.org/kb/personalized-extension-recommendations).
 
 ### Improve security for users everywhere {: #security }
 
-**Webpage data to DNS Resolver service**: For some Firefox users, Firefox routes DNS requests to a resolver service that has agreed to Mozilla’s [strict privacy standards for resolvers](https://wiki.mozilla.org/Security/DOH-resolver-policy). This provides added protection from privacy leaks to local networks and also from certain DNS security attacks. System logs of your DNS requests are deleted from the service within 24 hours and are only used for the purpose of DNS resolution.  [Learn more](https://support.mozilla.org/kb/firefox-dns-over-https#w_switching-providers) or see our default DNS resolver service providers below:
+**Webpage data to DNS Resolver service**: For [some Firefox users](https://support.mozilla.org/kb/firefox-dns-over-https), Firefox routes DNS requests to a resolver service that has agreed to Mozilla’s [strict privacy standards for resolvers](https://wiki.mozilla.org/Security/DOH-resolver-policy). This provides added protection from privacy leaks to local networks and also from certain DNS security attacks. System logs of your DNS requests are deleted from the service within 24 hours and are only used for the purpose of DNS resolution. [Learn more](https://support.mozilla.org/kb/firefox-dns-over-https#w_switching-providers) or see our default DNS resolver service providers below:
 
 * [__Cloudflare__](https://developers.cloudflare.com/1.1.1.1/privacy/firefox/)
 * [__NextDNS__](https://nextdns.io/privacy)
@@ -61,19 +67,19 @@ Firefox displays content, such as Add-on Recommendations, Top Sites (websites su
 * [__CIRA__](https://www.cira.ca/cybersecurity-services/canadian-shield/privacy)
 * [__Shaw__](https://www.shaw.ca/dns-statement)
 
-**Technical data for updates**: Desktop versions of Firefox check for browser updates by persistently connecting to Mozilla servers. Your Firefox version, language, and device operating system are used to apply the correct updates. Mobile versions of Firefox may connect to another service if you used one to download and install Firefox. [Learn more](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
+**Technical data for updates**: Maintaining the latest version of Firefox is important to help keep you safe against vulnerabilities. Desktop versions of Firefox check for browser updates by persistently connecting to Mozilla servers. Your Firefox version, language, and device operating system are used to apply the correct updates. Mobile versions of Firefox may connect to another service if you used one to download and install Firefox. [Learn more](https://support.mozilla.org/kb/how-stop-firefox-automatically-making-connections#w_auto-update-checking).
 {: #auto-updates }
 
-**Technical data for add-ons blocklist**: Firefox for Desktop and Android periodically connect to Mozilla to protect you and others from malicious add-ons.  Your Firefox version and language, device operating system, and list of installed add-ons are needed to apply and update the add-ons blocklist. [Learn more](https://support.mozilla.org/kb/how-stop-firefox-making-automatic-connections).
+**Technical data for add-ons blocklist**: Firefox for Desktop and Android periodically connect to Mozilla to protect you and others from malicious add-ons. Your Firefox version and language, device operating system, and list of installed add-ons are needed to apply and update the add-ons blocklist. [Learn more](https://support.mozilla.org/kb/how-stop-firefox-making-automatic-connections).
 
 **Webpage and technical data to Google’s SafeBrowsing service**: To help protect you from malicious downloads, Firefox sends basic information about unrecognized downloads to Google's SafeBrowsing Service, including the filename and the URL it was downloaded from. [Learn more](https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work) or read [Google’s Privacy Policy](https://www.google.com/policies/privacy/). Opting out prevents Firefox from warning you of potentially illegitimate or malicious websites or downloaded files.
 
 **Webpage and technical data to Certificate Authorities**: When you visit a secure website (usually identified with a URL starting with "HTTPS"), Firefox validates the website's [certificate](https://support.mozilla.org/kb/secure-website-certificate). This may involve Firefox sending certain information about the website to the Certificate Authority identified by that website. Opting out increases the risk of your private information being intercepted. [Learn more](https://support.mozilla.org/kb/advanced-settings-browsing-network-updates-encryption#w_certificates-tab).
 
-### Crash reports {: #crash-reporter }
-By default on desktop versions of Firefox, we will ask you to share a report with more detailed information about crashes with Mozilla, but you always have the choice to decline.
+### Send crash reports {: #crash-reporter }
+By default, on desktop versions of Firefox, we will ask you to share a report with more detailed information about crashes with Mozilla, but you always have the choice to decline. If you choose to share the report, the following information will be sent to us:
 
-* __Sensitive data__:  Crash reports include a ‘dump file’ of Firefox’s memory contents at the time of the crash, which may contain data that identifies you or is otherwise sensitive to you.
+* __Memory contents__:  Crash reports include a ‘dump file’ of Firefox’s memory contents at the time of the crash, which may contain data that identifies you or is otherwise sensitive to you.
 
 * __Webpage data__:  Crash reports include the active URL at time of crash.
 
@@ -83,64 +89,37 @@ Read the full documentation [here](https://firefox-source-docs.mozilla.org/toolk
 
 ### Measure and support our marketing
 
-* __Campaign and Referral Data__: This helps Mozilla understand the effectiveness of our marketing campaigns.
+__Campaign and Referral Data__: This helps Mozilla understand the effectiveness of our marketing campaigns.
 {: #referraltracking }
 
-    _On Desktop_: Firefox by default sends Mozilla HTTP data that may be included with Firefox’s installer.  This enables us to determine the website domain or advertising campaign (if any) that referred you to our download page. Read the [documentation](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) or [opt-out](https://support.mozilla.org/kb/desktop-privacy) before installation.
-
-    _On Mobile_: Firefox for iOS and Android by default send mobile campaign data to Adjust, our analytics vendor, which has its own [privacy policy](https://www.adjust.com/terms/privacy-policy/).  Mobile campaign data includes a Google advertising ID or Android ID, IP address, timestamp, country, language/locale, operating system, and app version. Read the [documentation](https://dictionary.telemetry.mozilla.org/apps/fenix?itemType=metrics&page=1&search=adjust).
+Firefox by default sends Mozilla HTTP data that may be included with Firefox’s installer. This enables us to determine the website domain or advertising campaign (if any) that referred you to our download page. Read the [documentation](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html#attribution) or [opt-out](https://support.mozilla.org/en-US/kb/desktop-attribution-privacy) before installation. Firefox by default also sends marketing campaign data to Adjust, our analytics vendor, which has its own [privacy policy](https://www.adjust.com/terms/privacy-policy/). Campaign data includes a Google advertising ID or Android ID, IP address, timestamp, country, language/locale, operating system, and app version. Read the [documentation](https://dictionary.telemetry.mozilla.org/apps/fenix?itemType=metrics&page=1&search=adjust).
 {: #thirdparty }
-
-### Firefox Suggest and Top Pick {: #searches }
-
-Mozilla is developing a new feature that helps deliver you better information with less effort. It’s called Firefox Suggest and an early version of it is currently available to users in the United States. By default, Firefox Suggest shows you recommended and sponsored content based on local data stored on your own computer, such as websites from your browsing history, bookmarks and open tabs. 
-
-* __Sites you visit__: Firefox sends Mozilla which suggestions you click or dismiss and Mozilla may share that data with its [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners).
-
-* __Location data__: Firefox temporarily sends Mozilla your IP address which we use to suggest content based on your country, state, and city. Mozilla may share location information with our partners, but partners will not receive your IP address. 
-
-* __Technical & interaction data__: Firefox sends Mozilla data such as the number of times Firefox suggests or displays content and your clicks on that content, as well as basic data about your interactions with Firefox Suggest. Mozilla shares information with our [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners) about how many times suggestions are shown and clicked for verification and feature improvement. 
-
-If you choose to enable "Improve the Firefox Suggest Experience," Firefox shares the following information to improve your browsing experience and to improve the service:
-
-* __Searches__: Firefox sends Mozilla what you type into the search bar and Mozilla may share that data with its [partners](https://support.mozilla.org/kb/firefox-suggest#w_who-are-mozillas-partners). 
-
-We take measures to limit our and our partners’ ability to identify you. [Learn more](https://support.mozilla.org/kb/firefox-suggest?as=u&utm_source=inproduc).
 
 ---
 
 ## If you use these features, Firefox will share data to provide you functionality and help us improve our products and services: {: #optional-features }
 
-### Firefox Accounts {: #firefox-accounts }
+### Mozilla Accounts {: #Mozilla-accounts }
 
-* __Registration data__: Mozilla receives your email address and a hash of your password when you create a Firefox Account or sign-up to Join Firefox. You can choose to include a display name or profile image. Your email address is sent to our email vendor, Acoustic, which has its own [privacy policy](https://acoustic.com/privacy-notice/).
+Mozilla receives registration, location, interaction and technical data when you create and use a Mozilla account. See the [Mozilla Accounts Privacy Notice](https://www.mozilla.org/privacy/mozilla-accounts/) for more information. 
 
-* __Location data__: For security purposes, we store the IP addresses used to access your Firefox Account in order to approximate your city and country. We use this data to send you email alerts if we detect suspicious activity, such as account logins from other locations.
+### Review Checker {: #review-checker }
 
-* __Interaction data__: We receive data such as your visits to the Firefox Accounts website, dashboards and menu preferences, what products and services you use in connection with your Firefox Account, and your interactions with our emails and SMS messages. We use this to understand your use of our products and services and to send you more useful Firefox Account Tips and in-product messages. Learn more about interaction data we collect in the [Glean Dictionary](https://dictionary.telemetry.mozilla.org/apps/accounts_frontend).
+Users in the US can opt-in to Review Checker, our guide to product reviews powered by Mozilla’s [Fakespot](https://www.fakespot.com/), which helps you understand how reliable product reviews are on [certain shopping sites](https://support.mozilla.org/en-US/kb/review-checker-review-quality). 
 
-* __Technical data__: To display which devices are synced to your Firefox Account and for security functionality, we store your device operating system, browser and version, timestamp, locale, and the same information for devices connected to your account. If you use your Firefox Account to log into other websites or services (such as AMO or Pocket), we receive the timestamp of those log-ins.
-
-Read the full documentation or learn more, including how to manage your Firefox Account data or our data practices for [websites and email](https://www.mozilla.org/privacy/websites/).  You can also read the privacy notices for our Firefox Account connected services, which are:
-
-* [Firefox Monitor](https://www.mozilla.org/privacy/firefox-monitor)
-* [Firefox Notes](https://addons.mozilla.org/firefox/addon/notes-by-firefox/)
-* [Pocket](https://getpocket.com/privacy/)
-* [Firefox Sync](https://www.mozilla.org/privacy/firefox/#sync)
-* [Firefox Relay](https://www.mozilla.org/privacy/firefox-relay/)
-* [Mozilla VPN](https://www.mozilla.org/privacy/mozilla-vpn/)
+* __Technical and interaction data__: We use Oblivious HTTP ([OHTTP](https://datatracker.ietf.org/doc/draft-ietf-ohai-ohttp/)) with our partner [Fastly](https://www.fastly.com/privacy/) to provide the service, while ensuring that any data identifying products, URLs, and request payloads are unlinkable to you. For more information about Review Checker, including what websiteshow to turn it off, you can read the [documentation](https://support.mozilla.org/kb/review-checker-review-quality). 
 
 ### Sync {: #sync }
 
-* __Synced data__: If you enable Sync, Mozilla receives the information that you sync across devices in encrypted form. This may include Firefox tabs, add-ons, passwords, payment autofill information, bookmarks, history, and preferences.  Deleting your Firefox Account will delete related Firefox Sync content. You can also read the [documentation](https://moz-services-docs.readthedocs.io/en/latest/sync/).
+* __Synced data__: If you enable Sync, Mozilla receives the information that you sync across devices in encrypted form. This may include Firefox tabs, add-ons, passwords, payment autofill information, bookmarks, history, and preferences.  Deleting your Mozilla Account will delete related Firefox Sync content. You can also read the [documentation](https://moz-services-docs.readthedocs.io/en/latest/sync/).
 
 * __Technical and Interaction data__: If you enable sync, Firefox will periodically send basic information using Telemetry about the most recent attempt to sync your data, such as when it took place, whether it succeeded or failed, and what type of device is attempting to sync. You can also read the [documentation](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/sync-ping.html).
 
-[Learn more](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), including how to enable or disable sync.
+[Learn more](https://support.mozilla.org/kb/how-do-i-set-sync-my-computer), including how to enable or disable Sync.
 
 ### Location {: #location-services }
 
-* __Location data to Google's geolocation service__: Firefox always asks before determining and sharing your location with a requesting website (for example, if a map website needs your location to provide directions).  To determine location, Firefox may use your operating system’s geolocation features, Wi-fi networks, cell phone towers, or IP address, and may send this data to Google's geolocation service, which has its own [privacy policy](https://www.google.com/privacy/lsf.html).
+* __Location data to Google's geolocation service__: Firefox always asks before determining and sharing your location with a requesting website (for example, if a map website needs your location to provide directions). To determine location, Firefox may use your operating system’s geolocation features, Wi-fi networks, cell phone towers, or IP address, and may send this data to Google's geolocation service, which has its own [privacy policy](https://www.google.com/privacy/lsf.html).
 
 [Learn more](https://www.mozilla.org/firefox/geolocation/).
 
@@ -166,7 +145,11 @@ You can install Add-ons from addons.mozilla.org (“AMO”) or from the Firefox 
 
 ### Footnote
 
+To make requests regarding your personal data, please contact us through our [Data Subject Access Request Portal](https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0). If you have any other questions regarding personal data or our privacy practices, please contact us at compliance@mozilla.com. We respond to all requests we receive from individuals wishing to exercise their data protection rights in accordance with applicable data protection laws.
+
 This privacy notice is for the most recent general release version of Firefox distributed by Mozilla.  If you obtain Firefox elsewhere, or are running an older version, your copy of Firefox may contain different privacy characteristics.
 {: #pre-release }
 
 Mozilla’s pre-release versions of Firefox (which are distributed through channels such as Nightly, Beta, Developer Edition and TestFlight) are development platforms frequently updated with experimental features and studies.  In addition to the data collection described in this Privacy Notice, these versions by default may send certain types of web activity and crash data to Mozilla and in some cases to our partners.  Any data collection or sharing adheres to our [Firefox data collection policy](https://wiki.mozilla.org/Firefox/Data_Collection) and we will always be transparent and provide you with controls.
+
+


### PR DESCRIPTION
Updated to address change from Fx > Mz Accounts, so removed (formerly named) Firefox Accounts section from this notice and redirected to new, separate Mozilla Accounts Privacy Notice. 

Also updated verbiage in relation to search functionality, Search & Suggest, Review Checker (Fakespot) and added language re: personal data requests to footnote. 

NB: current url for CIRA isn't working. There is no new url - we're asking them to restore the old url.