### PR TITLE
Update Smart Window Privacy Notice (September 2026)

### DIFF
--- a/en/smart_window_privacy_notice.md
+++ b/en/smart_window_privacy_notice.md
@@ -55,10 +55,74 @@ Mozilla aims to remain at the forefront of AI browser technology and may update 
 
 ## Lawful bases
 
-Smart Window’s lawful basis table defines terms as laid out in the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/).
+Smart Window’s lawful basis table defines terms as laid out in the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/#notice). 
 
-| What we use your data for | What data we process | Our lawful basis | More information, including choosing how you want to share this data in Firefox |
-| ------------------------- | -------------------- | ---------------- | ------------------------------------------------------------------------------ |
-| To create Memories about your activity | Settings<br><br>Browsing data<br><br>Search data<br><br>Content | **Consent** when you ask Smart Window to remember things about you, or deliberately provide it with certain pieces of information.<br><br>**Legitimate interest** in providing additional functionality, and a more personalized experience. | Memories are stored locally on your device, and remain within your control. You can turn off Memory creation, or delete specific Memories at any time. |
-| To provide the Smart Window assistant | Location<br><br>Language preference<br><br>Unique identifiers<br><br>Interaction data<br><br>Browsing data<br><br>Search data<br><br>Content | **Contract** to provide you with the necessary functionality for Smart Window to operate.<br><br>**Consent** when processing is necessary to perform specific tasks that you have requested.<br><br>**Legitimate interest** in providing additional functionality and a personalized experience. | You can choose which AI model powers the assistant, and can switch models at any time, or can customize Smart Window with your own model.<br><br>Mozilla does not train models on your Smart Window interactions, and works to protect your data, as described [here](https://support.mozilla.org/kb/smart-window-safety). |
-| To maintain and improve features, performance and stability | Technical data<br><br>Location<br><br>Settings data<br><br>Unique identifiers<br><br>System performance data<br><br>Interaction data<br><br>Browsing data<br><br>Content | **Contract** to ensure that Smart Window continues to function as intended.<br><br>**Legitimate interest** in improving features, performance and stability.<br><br>**Consent** when you choose to share chat logs or browsing data to help us identify, troubleshoot and diagnose issues, or improve the Smart Window product. | You can choose to share feedback about Smart Window, including sharing chat logs for human review. We never review this data without your consent. |
+<table>
+    <thead>
+        <tr>
+            <th>What we use your data for</th>
+            <th>What data we process</th>
+            <th>Our lawful basis</th>
+            <th>More information, including choosing how you want to share this data in Firefox</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>To create Memories about your activity</td>
+            <td>
+                <ul>
+                    <li>Settings</li>
+                    <li>Browsing data</li>
+                    <li>Search data</li>
+                    <li>Content</li>
+                </ul>
+            </td>
+            <td>
+                <p><strong>Consent</strong> when you ask Smart Window to remember things about you, or deliberately provide it with certain pieces of information.</p>
+                <p><strong>Legitimate interest</strong> in providing additional functionality, and a more personalized experience.</p>
+            </td>
+            <td>Memories are stored locally on your device, and remain within your control. You can <a href="https://support.mozilla.org/kb/smart-window-memories">turn off Memory creation, or delete specific Memories</a> at any time.</td>
+        </tr>
+        <tr>
+            <td>To provide the Smart Window assistant</td>
+            <td>
+                <ul>
+                    <li>Location</li>
+                    <li>Language preference</li>
+                    <li>Unique identifiers</li>
+                    <li>Interaction data</li>
+                    <li>Browsing data</li>
+                    <li>Search data</li>
+                    <li>Content</li>
+                </ul>
+            </td>
+            <td>
+                <p><strong>Contract</strong> to provide you with the necessary functionality for Smart Window to operate.</p>
+                <p><strong>Consent</strong> when processing is necessary to perform specific tasks that you have requested.</p>
+                <p><strong>Legitimate interest</strong> in providing additional functionality and a personalized experience.</p>
+            </td>
+            <td><a href="https://support.mozilla.org/kb/smart-window-models">You can choose which AI model powers the assistant</a>, and can switch models at any time, or can <a href="https://support.mozilla.org/kb/smart-window-byom">customize</a> Smart Window with your own model. Mozilla does not train models on your Smart Window interactions, and works to protect your data, as described <a href="https://support.mozilla.org/kb/smart-window-safety">here</a>.</td>
+        </tr>
+        <tr>
+            <td>To maintain and improve features, performance and stability</td>
+            <td>
+                <ul>
+                    <li>Technical data</li>
+                    <li>Location</li>
+                    <li>Settings data</li>
+                    <li>Unique identifiers</li>
+                    <li>System performance data</li>
+                    <li>Interaction data</li>
+                    <li>Browsing data</li>
+                    <li>Content</li>
+                </ul>
+            </td>
+            <td>
+                <p><strong>Contract</strong> to ensure that Smart Window continues to function as intended.</p>
+                <p><strong>Legitimate interest</strong> in improving features, performance and stability.</p>
+                <p><strong>Consent</strong> when you choose to share chat logs or browsing data to help us identify, troubleshoot and diagnose issues, or improve the Smart Window product.</p>
+            </td>
+            <td>You <a href="https://support.mozilla.org/kb/smart-window-user-feedback">can choose to share feedback</a> about Smart Window, including sharing chat logs for human review. We never review this data without your consent.</td>
+        </tr>
+    </tbody>
+</table>

--- a/en/smart_window_privacy_notice.md
+++ b/en/smart_window_privacy_notice.md
@@ -1,7 +1,7 @@
 # Smart Window Privacy Notice
 
-April 21, 2026
-{: datetime="2026-04-21" }
+Last updated September 1, 2026
+{: datetime="2026-09-01" }
 
 ## Smart Window allows you to use AI to enhance your browsing experience
 
@@ -11,11 +11,9 @@ Smart Window is completely optional and opt-in. If activated, it builds on the c
 
 When you use Smart Window, Mozilla processes certain data specifically to provide AI-enhanced features. That processing is governed by this Smart Window Privacy Notice, in addition to the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/). You can open a Firefox classic window at any time in the File menu of your browser, or toggle between Smart and classic windows using the icon in the top right corner. Your use of classic windows will be governed by the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/), unless and until you choose to open a new Smart Window.
 
-To the extent there is any inconsistency between the Firefox and Smart Window privacy notices, this notice will govern with respect to Smart Window-related processing.  Your use of Smart Window is also subject to the [Smart Window Terms of Use](https://www.mozilla.org/about/legal/terms/smart-window/) and the [Firefox Terms of Use](https://www.mozilla.org/about/legal/terms/firefox/).
+To the extent there is any inconsistency between the Firefox and Smart Window privacy notices, this notice will govern with respect to Smart Window-related processing. Your use of Smart Window is also subject to the [Smart Window Terms of Use](https://www.mozilla.org/about/legal/terms/smart-window/) and the [Firefox Terms of Use](https://www.mozilla.org/about/legal/terms/firefox/).
 
 You need a Mozilla account to use Smart Window. Creating and using that account involves processing additional data — such as account activity and contact information — as described in the [Mozilla Accounts Privacy Notice](https://www.mozilla.org/privacy/mozilla-accounts/).
-
-You can open a Firefox classic window at any time in the File menu of your browser, or toggle between Smart and classic windows using the icon in the top right corner. Your use of classic windows will be governed by the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/), unless and until you choose to open a new Smart Window.
 
 You can choose to use Smart Window with a model endpoint other than those provided by Mozilla by customizing the settings in your Smart Window preferences. Note that if you select a model endpoint not offered in the Smart Window interface, your information will be processed by that endpoint and will not be routed through a Mozilla server. If that endpoint is operated by a third party, its terms of service and privacy notice will apply.
 
@@ -27,23 +25,25 @@ Smart Window infers information about you based on your interactions with the as
 
 You can review or delete a specific Memory in your settings, block all Memories from being used in a particular chat, or remove a specific Memory from a chat and re-run the associated query without it. More information about how to manage your Memories can be found [here](https://support.mozilla.org/kb/smart-window-memories).
 
-### To provide the Smart Window Assistant
+### To provide the Smart Window assistant
 
-The assistant feature lives in your Smart Bar, and can help improve your searches, answer questions, retrieve pages you have visited in classic or Smart Windows, and make information on the web easier to consume. To provide these features, the Assistant processes your query and, where relevant to your request, limited browsing context and stored Memories. When you submit a query in the Smart Bar, the assistant uses a local (on device) intent classification model to determine whether the query is best addressed by a **chat** or a **search**.
+The assistant feature lives in your Smart Bar, and can help improve your searches, answer questions, retrieve pages you have visited in classic or Smart Windows, and make information on the web easier to consume. When you ask it to do so, it can also perform certain actions on your behalf, such as closing or organizing your open tabs. To provide these features, the assistant processes your query and, where relevant to your request, browsing context and stored Memories. When you submit a query in the Smart Bar, the assistant uses a local (on-device) intent classification model to determine whether the query is best addressed by a **chat** or a **search**.
 
-If your query is classified as a chat, the assistant will leverage any potentially relevant stored Memories or browsing context to tailor the prompt. For example, if your query relates to your past browsing activity (such as “what were the ingredients of that chicken pasta recipe I saw yesterday?” or “compare the five different black sneakers I looked at last week”), the assistant may review limited browsing data from your history—namely page titles and URLs—to identify potentially relevant content, access those pages in the background, and incorporate relevant content from those pages into the proposed prompt. You can exclude specific pages by deleting them from your history or bookmarks or, when the assistant’s search is limited to open tabs, by closing the relevant tab.
+If your query is classified as a chat, the assistant will leverage any potentially relevant stored Memories or browsing context to tailor the prompt. For example, if your query relates to your past browsing activity (such as “what were the ingredients of that chicken pasta recipe I saw yesterday?” or “compare the five different black sneakers I looked at last week”), the assistant may review limited browsing data from your history — namely page titles and URLs — to identify potentially relevant content, access those pages in the background, and incorporate relevant content from those pages into the proposed prompt. You can exclude specific pages by deleting them from your history or bookmarks or, when the assistant’s search is limited to open tabs, by closing the relevant tab.
 
 Where your query appears to contain location-related information, the assistant may infer your location to further personalize prompts.
 
 The assistant sends the full prompt (including your query, any relevant Memories, and any additional relevant browsing context) to a Mozilla server.
 
-Upon receipt, Mozilla forwards the request to a third-party large language model (LLM) on your behalf. The LLM receives the request from Mozilla, not directly from you, and sees a Mozilla IP address rather than your own. The request includes only the information needed to generate a response. Additional information about our LLM partners, and how you can select which LLM you use, is available [here](https://support.mozilla.org/kb/smart-window-models).
+Upon receipt, Mozilla forwards the request to a third-party large language model (LLM) on your behalf. The LLM receives the request from Mozilla, not directly from you, and sees a Mozilla IP address rather than your own. The request includes only the information needed to generate a response or perform the requested action. Additional information about our LLM partners, and how you can select which LLM you use, is available [here](https://support.mozilla.org/kb/smart-window-models).
 
-The LLM provides a response based on information in its knowledge base and information included in the prompt. We share that response with you in the chat, along with the specific Memories included in the prompt. You can then choose to disable Memories and re-run the prompt without them, continue or close the chat, or initiate a broader web search.
+The LLM provides a response based on information in its knowledge base and information included in the prompt. Where it does not have sufficient information in its knowledge base, Mozilla calls our search index partner on your behalf to review the query and returns any response to the assistant. The request does not include personal identifiers that link the query to you.
+
+We share that response with you in the chat, along with the specific Memories included in the prompt. You can then choose to disable Memories and re-run the prompt without them, continue or close the chat, or initiate a broader web search.
 
 If the assistant cannot provide a satisfactory response or classifies your query as a **search**, it may tailor your query using relevant Memories, browser context, or chat history to help find the information you seek. Once submitted, your search provider will process that query in accordance with its own Privacy Notice.
 
-### To maintain improve features, performance and stability
+### To maintain and improve features, performance and stability
 
 We also process data to keep Smart Window operational, improve features and performance, and identify, troubleshoot, and diagnose issues, including feedback you choose to provide us with about the assistant. Mozilla never retains chat logs without your permission.
 
@@ -52,3 +52,13 @@ We designed Smart Window to give users access to new, innovative features as soo
 ## Changes
 
 Mozilla aims to remain at the forefront of AI browser technology and may update Smart Window and this notice by posting those changes online and updating the effective date of this notice. If the changes are substantive, we will also announce the updates more prominently through Mozilla's usual channels for such announcements, such as through an in-product notification.
+
+## Lawful bases
+
+Smart Window’s lawful basis table defines terms as laid out in the [Firefox Privacy Notice](https://www.mozilla.org/privacy/firefox/).
+
+| What we use your data for | What data we process | Our lawful basis | More information, including choosing how you want to share this data in Firefox |
+| ------------------------- | -------------------- | ---------------- | ------------------------------------------------------------------------------ |
+| To create Memories about your activity | Settings<br><br>Browsing data<br><br>Search data<br><br>Content | **Consent** when you ask Smart Window to remember things about you, or deliberately provide it with certain pieces of information.<br><br>**Legitimate interest** in providing additional functionality, and a more personalized experience. | Memories are stored locally on your device, and remain within your control. You can turn off Memory creation, or delete specific Memories at any time. |
+| To provide the Smart Window assistant | Location<br><br>Language preference<br><br>Unique identifiers<br><br>Interaction data<br><br>Browsing data<br><br>Search data<br><br>Content | **Contract** to provide you with the necessary functionality for Smart Window to operate.<br><br>**Consent** when processing is necessary to perform specific tasks that you have requested.<br><br>**Legitimate interest** in providing additional functionality and a personalized experience. | You can choose which AI model powers the assistant, and can switch models at any time, or can customize Smart Window with your own model.<br><br>Mozilla does not train models on your Smart Window interactions, and works to protect your data, as described [here](https://support.mozilla.org/kb/smart-window-safety). |
+| To maintain and improve features, performance and stability | Technical data<br><br>Location<br><br>Settings data<br><br>Unique identifiers<br><br>System performance data<br><br>Interaction data<br><br>Browsing data<br><br>Content | **Contract** to ensure that Smart Window continues to function as intended.<br><br>**Legitimate interest** in improving features, performance and stability.<br><br>**Consent** when you choose to share chat logs or browsing data to help us identify, troubleshoot and diagnose issues, or improve the Smart Window product. | You can choose to share feedback about Smart Window, including sharing chat logs for human review. We never review this data without your consent. |


### PR DESCRIPTION
Updates the English Smart Window Privacy Notice per the September 2026 revision.
Source: https://docs.google.com/document/d/1vKK4L71UQxtcASYve1pRXdyZEuNFAKRxkGuOhX9wOFM/edit

Changes: new effective date (Sept 1, 2026), removed duplicated paragraph, assistant actions on user's behalf, new search index partner paragraph, new Lawful bases section and table, heading typo fix.