### PR TITLE
Update firefox_terms_of_use.md

### DIFF
--- a/en/firefox_terms_of_use.md
+++ b/en/firefox_terms_of_use.md
@@ -85,3 +85,5 @@ Attn: Mozilla – Legal Notices <br>
 San Francisco, CA 94103
 
 legal-notices@mozilla.com
+
+Please note that we do not accept information requests from government agencies at the above address.  See our [Transparency Page](https://www.mozilla.org/en-US/about/policy/transparency/) for details about how to submit such requests.


### PR DESCRIPTION
Clarifying that the Legal Notices email should not be used for government requests, and providing the right contact information.